### PR TITLE
Add go-load --skip-binlog, GTID/replication docs, and multi-version test matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ log/*
 /*.sql.gz
 /metadata.json
 /checksums.txt
+
+# Multi-version matrix test output and manual test dumps
+test/matrix-out/
+/test-seed/

--- a/Makefile
+++ b/Makefile
@@ -113,15 +113,30 @@ build-all: build-linux build-linux-arm64 build-darwin build-darwin-arm64 \
 
 # ── Test ───────────────────────────────────────────────────────────────────────
 
-# Unit tests only — no MySQL connection required
+# Unit tests only — no MySQL connection required.
+# dump: whitelist (the package mixes in tests that need a live server);
+# load: all tests are MySQL-free (fake driver), run unfiltered.
 test-unit:
 	@echo "Running unit tests..."
 	$(GOTEST) -v ./internal/dump/ $(UNIT_TEST_FLAGS)
+	$(GOTEST) -v ./internal/load/
 
 # Integration tests — require a live MySQL instance (see test/test.ini)
 test-integration:
 	@echo "Running integration tests (requires MySQL)..."
-	$(GOTEST) -v -timeout 60s ./internal/dump/
+	$(GOTEST) -v -timeout 60s ./internal/dump/ ./internal/load/
+
+# ── Multi-version MySQL matrix (5.7 / 8.0 / 8.4 / 9) ──────────────────────────
+# Containers listen on 33057/33080/33084/33090 — safe alongside a local 3306.
+
+test-versions-up:
+	docker compose -f test/docker-compose.versions.yml up -d --wait
+
+test-versions: build build-go-load
+	./test/test-versions.sh
+
+test-versions-down:
+	docker compose -f test/docker-compose.versions.yml down -v
 
 # Alias: same as test-unit by default
 test: test-unit

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ per thread with a consistent, point-in-time snapshot using InnoDB MVCC — simil
 - [Common examples](#common-examples)
 - [Output files](#output-files)
 - [Restoring](#restoring)
+- [Replication and GTIDs](#replication-and-gtids)
+- [Limitations](#limitations)
 - [Required privileges](#required-privileges)
 - [Cloud SQL notes](#cloud-sql-notes)
 
@@ -45,11 +47,16 @@ per thread with a consistent, point-in-time snapshot using InnoDB MVCC — simil
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| MySQL 5.7 | ✅ | Full support |
-| MySQL 8.0.x | ✅ | Uses `SHOW MASTER STATUS` / `SHOW REPLICA STATUS` |
-| MySQL 8.4+ | ✅ | Uses `SHOW BINARY LOG STATUS` / `SHOW REPLICA STATUS` |
+| MySQL 5.7 | ✅ | Full support (matrix-tested on 5.7.44) |
+| MySQL 8.0.x | ✅ | Uses `SHOW MASTER STATUS` / `SHOW REPLICA STATUS` (matrix-tested on 8.0.45) |
+| MySQL 8.4 | ✅ | Uses `SHOW BINARY LOG STATUS` / `SHOW REPLICA STATUS` (matrix-tested on 8.4.10) |
+| MySQL 9.x | ✅ | Same as 8.4 (matrix-tested on 9.7.1) |
 | Google Cloud SQL MySQL 5.7 | ✅ | Direct TCP (private IP) |
 | Google Cloud SQL MySQL 8.0 | ✅ | Direct TCP (private IP) |
+
+Every version above is exercised by `make test-versions` (see [Building](#building)):
+GTID capture, full restore round trip with checksum verification, and
+`--skip-binlog` GTID invariance.
 
 Authentication: `mysql_native_password` (5.7) and `caching_sha2_password` (8.0+)
 are both handled automatically by the driver.
@@ -90,7 +97,19 @@ make test
 
 # Run integration tests (requires MySQL at 127.0.0.1:3306)
 make test-integration
+
+# Multi-version matrix: dump/restore/skip-binlog against MySQL 5.7, 8.0, 8.4, 9
+# Containers use ports 33057/33080/33084/33090 — safe alongside a local 3306.
+make test-versions-up      # start the four containers (first run pulls images)
+make test-versions         # build binaries + run test/test-versions.sh
+make test-versions-down    # tear down (removes volumes)
 ```
+
+The matrix (`test/docker-compose.versions.yml` + `test/test-versions.sh`)
+verifies, per version: GTID capture in `metadata.json`, a full
+drop-database→restore→checksum-verify round trip, and that
+`go-load --skip-binlog` leaves `gtid_executed` byte-identical.
+MySQL 5.7 runs under amd64 emulation on Apple Silicon (Rosetta).
 
 The `VERSION` file controls the embedded version string. Override at build time:
 
@@ -545,6 +564,279 @@ ls /backups/myapp/*.sql.gz | xargs -P4 -I{} sh -c 'zcat {} | mysql -h target-hos
 
 For point-in-time recovery, apply binary logs from the position recorded in
 `master-data.sql` (or `metadata.json` `binlog_file`/`binlog_position`).
+
+---
+
+## Replication and GTIDs
+
+go-dump captures the executed GTID set (and binlog file/position) **inside the lock
+window**, at the exact instant the worker snapshots are opened — so the recorded
+coordinates match the dumped data. This is what makes a dump usable for seeding a
+replica.
+
+Two distinct workflows:
+
+| Goal | How |
+|------|-----|
+| Seed a new replica and start replication | Dump **with** `--get-master-status`, restore, then set `gtid_purged` and configure replication (manual SQL today — see below) |
+| Repopulate tables/databases without touching replication | Dump **without** `--get-master-status` (the default) and just restore |
+
+### Dumping with GTIDs (replica seeding)
+
+```bash
+# On (or against) the primary:
+go-dump \
+  --ini-file /etc/go-dump/primary.ini \
+  --databases myapp \
+  --destination /backups/seed \
+  --threads 8 \
+  --get-master-status \
+  --checksum \
+  --execute
+```
+
+This records in `/backups/seed/metadata.json`:
+
+```json
+"binlog_file": "binlog.000042",
+"binlog_position": 1421,
+"gtid_set": "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123"
+```
+
+and the same values in human-readable form in `master-data.sql` (a text report,
+not executable SQL — go-load skips it automatically).
+
+Restore onto the new replica, then configure replication:
+
+```bash
+# 1. Load the data (go-load prints the recorded binlog/GTID coordinates).
+#    --skip-binlog keeps the load out of the replica's own binlog/GTID history,
+#    so gtid_purged can be set afterwards without RESET MASTER.
+go-load --host replica1 --user root --password ... \
+  --directory /backups/seed --workers 8 --verify --skip-binlog
+```
+
+```sql
+-- 2. On the replica: set gtid_purged to the dump's snapshot GTID set
+--    (from metadata.json "gtid_set").
+--    gtid_purged can only be set while gtid_executed is empty. With
+--    --skip-binlog above (and a fresh instance), it already is. If the load
+--    ran WITHOUT --skip-binlog, clear the local GTID history first:
+--      RESET MASTER;                   -- MySQL <= 8.0 / 5.7
+--      RESET BINARY LOGS AND GTIDS;    -- MySQL 8.4+
+--    (destructive: wipes the replica's own binlogs — never run on the primary)
+SET GLOBAL gtid_purged = '3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123';
+
+-- 3. Point the replica at the primary using auto-positioning.
+CHANGE REPLICATION SOURCE TO
+  SOURCE_HOST = 'primary1.db.internal',
+  SOURCE_PORT = 3306,
+  SOURCE_USER = 'repl',
+  SOURCE_PASSWORD = '...',
+  SOURCE_AUTO_POSITION = 1;         -- MySQL 8.0.23+; use CHANGE MASTER TO / MASTER_AUTO_POSITION=1 on 5.7
+START REPLICA;                      -- START SLAVE on 5.7
+
+-- 4. Verify
+SHOW REPLICA STATUS\G               -- Replica_IO_Running / Replica_SQL_Running: Yes
+```
+
+Then prove the seed is clean with go-gtids — see the step-through guide below.
+
+### Verifying a replica with go-gtids (errant transaction check)
+
+[go-gtids](https://github.com/ChaosHour/go-gtids) is a companion tool that
+compares `gtid_executed` between two servers and reports **errant
+transactions** — GTIDs the replica has that its primary does not.
+
+**Why it matters:** an errant transaction means someone (or something) wrote
+directly to the replica. The replica's data has silently diverged from the
+primary, and the damage surfaces later at the worst time: if that replica is
+promoted during a failover, other replicas request its errant GTIDs from their
+new source, and either fail with error 1236 (`master has purged binary logs`)
+or — worse — apply changes the rest of the topology never had. Catching errant
+GTIDs while the topology is healthy is cheap; catching them mid-failover is an
+outage.
+
+**When to run it:**
+
+- **After seeding a replica** with go-dump/go-load (step 4 of the recipe
+  above) — proves the seed + `gtid_purged` handoff left nothing extra behind.
+- **Before any planned failover or promotion** — a clean check means
+  auto-positioning will work on every replica.
+- **Periodically / after incidents** — e.g. after someone had a root shell on
+  a replica, or after a load was run against the "wrong" host.
+- **After `go-load` into a live topology** — confirm the load landed where you
+  intended and nothing leaked onto a replica.
+
+**Step-through:**
+
+```bash
+# 1. Install (or download a release binary from the repo)
+go install github.com/ChaosHour/go-gtids/cmd/go-gtids@latest
+
+# 2. Credentials: go-gtids reads user/password from ~/.my.cnf
+cat ~/.my.cnf
+# [client]
+# user=root
+# password=s3cr3t
+
+# 3. Run it: -s is the primary (source), -t the replica (target)
+go-gtids -s primary1.db.internal -source-port 3306 -t replica1 -target-port 3306
+```
+
+Healthy output — each server's identity and GTID history, then the verdict:
+
+```
+[+] Source -> primary1 gtid_executed: 2ac8ec13-...:1-40593, ...
+[+] server_uuid: 2ac8ec13-...
+[+] Target -> replica1 gtid_executed: 2ac8ec13-...:1-40593, ...
+[+] server_uuid: 2af7e535-...
+[+] No Errant Transactions:
+```
+
+```bash
+# 4. If errant GTIDs ARE reported, remediate with the fix flags:
+#    -fix          inject empty transactions for the errant GTIDs on the SOURCE,
+#                  so the replica's history becomes a subset again (most common;
+#                  keeps auto-position failover working; the divergent DATA on
+#                  the replica still needs to be reconciled by you)
+#    -fix-replica  apply to the replica instead
+go-gtids -s primary1.db.internal -t replica1 -fix
+```
+
+> **Reading the output:** compare each server's `server_uuid` against the UUIDs
+> in the GTID sets. A range under the *replica's own* `server_uuid` that the
+> primary lacks = direct writes on the replica. The fix flags repair the **GTID
+> bookkeeping** (empty transactions make the sets consistent) — they do not and
+> cannot un-write the divergent rows. For data reconciliation, re-seed the
+> replica with go-dump/go-load, or use pt-table-checksum/pt-table-sync.
+
+Equivalent manual check, if you only have a mysql client:
+
+```sql
+-- On the replica: anything the replica executed that the primary didn't?
+SELECT GTID_SUBTRACT(@@global.gtid_executed, '<primary gtid_executed>');
+-- '' (empty) = clean; anything else = errant GTIDs
+```
+
+To prevent errant transactions in the first place, set
+`super_read_only = ON` on replicas (blocks even SUPER users; the replication
+applier is exempt), and use `go-load --skip-binlog` when a replica must be
+written to deliberately (it keeps the write out of the GTID history — though
+the data divergence is then yours to manage).
+
+For non-GTID (file/position) replication, use `binlog_file` / `binlog_position`
+from `metadata.json` instead:
+
+```sql
+CHANGE REPLICATION SOURCE TO
+  SOURCE_HOST = 'primary1.db.internal',
+  SOURCE_LOG_FILE = 'binlog.000042',
+  SOURCE_LOG_POS = 1421, ...;
+```
+
+> **Operational notes:**
+> - `RESET MASTER` is destructive on the replica (wipes its binlogs and GTID
+>   history). Only run it on the freshly-seeded replica, never on the primary.
+> - `SET GLOBAL gtid_purged` requires `SUPER` / `SYSTEM_VARIABLES_ADMIN`, which
+>   managed services (Cloud SQL, RDS) do not grant — use the provider's external
+>   replication API there instead.
+> - These post-restore steps are manual today. Automating them in go-load is
+>   planned — see [docs/GTID-REPLICATION.md](docs/GTID-REPLICATION.md).
+
+### Dumping without GTIDs (repopulating tables, replication-safe)
+
+This is the **default behaviour** — GTID/binlog capture is opt-in:
+
+```bash
+# No --get-master-status: no GTID or binlog state is recorded anywhere.
+go-dump \
+  --ini-file /etc/go-dump/prod.ini \
+  --tables "myapp.orders,myapp.order_items" \
+  --destination /backups/orders \
+  --threads 4 \
+  --add-drop-table \
+  --execute
+
+# Restore into an existing server without touching its replication state:
+go-load --host target-host --user app_admin --password ... \
+  --directory /backups/orders --workers 4
+```
+
+This is safe for replication because, unlike `mysqldump` (which embeds
+`SET @@GLOBAL.GTID_PURGED` by default when `gtid_mode=ON`), go-dump data files
+contain **only** `USE`, `SET NAMES`, `FOREIGN_KEY_CHECKS=0`, and `INSERT`
+statements. Restoring a go-dump can never overwrite the target's GTID state,
+stop its replication threads, or change its replication configuration —
+regardless of whether the dump was taken with `--get-master-status`.
+
+Two things to be aware of when loading into a live topology:
+
+- The load's writes go through the target's binlog like any other client
+  traffic. If the target is a **primary**, the restored rows replicate to its
+  replicas normally (usually what you want when repopulating a table). To load
+  **without** replicating downstream, use `go-load --skip-binlog` (below).
+- If the target is a **replica**, writing to it directly will make it diverge
+  from its primary (errant GTIDs). That is true of any client write, not
+  specific to go-dump — `--skip-binlog` avoids the errant GTIDs, but the data
+  divergence remains yours to manage.
+
+### Loading without writing the binlog (`--skip-binlog`)
+
+`go-load --skip-binlog` runs `SET SQL_LOG_BIN=0` on **every** connection the
+load uses (session-scoped, so it is applied per-connection, schema and data
+alike). The restored rows are written to the target only: nothing goes to its
+binlog, nothing replicates to its replicas, and nothing is added to its
+`gtid_executed`.
+
+```bash
+# Repopulate a table on a primary WITHOUT pushing the load to its replicas:
+go-load --host primary1 --user admin --password ... \
+  --directory /backups/orders --workers 4 --skip-binlog
+```
+
+Notes:
+
+- Requires `SUPER` or `SYSTEM_VARIABLES_ADMIN` on the target. Cloud SQL and RDS
+  do not grant these — go-load fails with a clear error there; drop the flag.
+- If the connection cannot disable binary logging, the load **aborts** rather
+  than continuing with a partially-logged restore.
+- When seeding a replica, loading with `--skip-binlog` keeps `gtid_executed`
+  empty on the fresh instance, which means `SET GLOBAL gtid_purged` works
+  without the destructive `RESET MASTER` step.
+
+---
+
+## Limitations
+
+Know these before relying on a dump for replica seeding or disaster recovery:
+
+- **Base tables only.** go-dump discovers `TABLE_TYPE = 'BASE TABLE'` — it does
+  **not** dump views, triggers, stored procedures/functions, or events. If your
+  schema uses them, capture them separately and load them after the data:
+
+  ```bash
+  mysqldump --no-data --no-create-info --routines --events --triggers \
+    -h source-host -u backup -p myapp > myapp-objects.sql
+  ```
+
+  A replica seeded without its views/routines will error on reads that use
+  them, even though replication itself runs fine.
+- **Users and grants are not dumped** unless `--all-databases
+  --include-system-databases` is used (raw `mysql.*` tables, on-prem only —
+  never against Cloud SQL/RDS). For portable account DDL, use
+  `pt-show-grants` or `mysqlpump --users` separately.
+- **Character sets:** dump files carry raw column bytes and are loaded on
+  default-charset (utf8mb4) connections. This round-trips utf8mb4/ascii/binary
+  columns correctly; schemas storing non-UTF-8 bytes in text columns (e.g.
+  latin1 with high-bit characters) should be test-restored and checksum-verified
+  before you rely on the dump.
+- **Non-InnoDB tables** are only write-protected during the brief lock window;
+  concurrent writes after the unlock can appear in their dump files (warned at
+  runtime).
+- **`CHECKSUM TABLE` runs after the locks are released** — on a live primary a
+  checksum mismatch does not necessarily mean a bad dump (see the caveat in
+  [Output files](#output-files)).
 
 ---
 

--- a/cmd/go-load/main.go
+++ b/cmd/go-load/main.go
@@ -34,6 +34,7 @@ func main() {
 		pattern    string
 		workers    int
 		dataOnly   bool
+		skipBinlog bool
 		verify     bool
 		resume     bool
 		quiet      bool
@@ -53,6 +54,7 @@ func main() {
 	flag.StringVar(&pattern, "pattern", "*.sql", "File glob pattern for data files in --directory. Use '*.sql.gz' for compressed dumps.")
 	flag.IntVar(&workers, "workers", 4, "Number of parallel workers for data files")
 	flag.BoolVar(&dataOnly, "data-only", false, "Skip schema (definition) files; load data files only")
+	flag.BoolVar(&skipBinlog, "skip-binlog", false, "Run SET SQL_LOG_BIN=0 on every load connection so the restore is not written to the target's binlog or replicated downstream. Requires SUPER or SYSTEM_VARIABLES_ADMIN.")
 	flag.BoolVar(&verify, "verify", false, "Verify checksums after loading (requires checksums.txt in --directory)")
 	flag.BoolVar(&resume, "resume", false, "Resume a previous load: skip files recorded in load-state.json")
 	flag.BoolVar(&quiet, "quiet", false, "Suppress INFO messages")
@@ -113,6 +115,11 @@ func main() {
 
 	imp := load.New(db, workers, dataOnly)
 	defer imp.Close()
+
+	if skipBinlog {
+		imp.SetSkipBinlog(true)
+		log.Warning("--skip-binlog: loaded data will NOT be written to the target's binlog — it will not replicate to any downstream replicas and adds nothing to gtid_executed.")
+	}
 
 	if directory != "" {
 		// Log useful context from the source dump's metadata if present.

--- a/docs/GTID-REPLICATION.md
+++ b/docs/GTID-REPLICATION.md
@@ -1,0 +1,155 @@
+# GTID & Replication: current state, gaps, and planned features
+
+Status of GTID handling in go-dump/go-load as of 2026-07-03, and the work needed
+to make replica seeding a one-command operation.
+
+## What works today
+
+### Dump side — complete
+
+- `--get-master-status` captures `SHOW MASTER STATUS` / `SHOW BINARY LOG STATUS`
+  (8.4+) **inside the lock window**, after the worker consistent snapshots are
+  opened and before `UNLOCK TABLES` (`internal/dump/taskmanager.go`,
+  `GetTransactions`). The recorded binlog file/position and `Executed_Gtid_Set`
+  therefore match the dumped data exactly — correct for replica seeding.
+- Coordinates are persisted twice:
+  - `metadata.json` → `binlog_file`, `binlog_position`, `gtid_set`
+    (`internal/dump/metadata.go`, `SetBinlog`)
+  - `master-data.sql` → human-readable text report
+- `--get-slave-status` records `SHOW REPLICA STATUS` (incl. `Executed_Gtid_Set`
+  / MariaDB `Gtid_Slave_Pos`, multi-source aware) to `slave-data.sql` — useful
+  when dumping from a replica to seed a sibling.
+- GTID capture is **opt-in** (both flags default to `false`), so default dumps
+  carry no replication state at all.
+- Data/definition files contain only `USE`, `SET NAMES binary`,
+  `FOREIGN_KEY_CHECKS=0`, `DROP TABLE IF EXISTS` (opt-in) and `INSERT`s. No
+  `SET @@GLOBAL.GTID_PURGED`, no `CHANGE MASTER`. Restores are replication-safe
+  by construction — the mysqldump `gtid_purged` footgun does not exist here.
+
+### Load side — partial
+
+- `go-load` reads `metadata.json` and **logs** the source binlog/GTID
+  coordinates (`cmd/go-load/main.go`).
+- `master-data.*` / `slave-data.*` are correctly excluded from loadable files
+  (`internal/load/importer.go`, `findFiles`).
+- `go-load --skip-binlog` runs `SET SQL_LOG_BIN=0` on every load connection
+  (`internal/load/importer.go`, `doLoadFile`) — loads without replicating
+  downstream or touching `gtid_executed`. Aborts (rather than degrading) if the
+  privilege is missing, with a Cloud SQL/RDS hint on error 1227.
+- Everything after the data load (`gtid_purged`,
+  `CHANGE REPLICATION SOURCE TO`, `START REPLICA`) is **manual** — documented in
+  README "Replication and GTIDs".
+
+## Gaps / planned features
+
+### 1. `go-load --set-gtid-purged` (highest value)
+
+Automate the GTID handoff after a seed restore.
+
+- Read `gtid_set` from `metadata.json` (fail with a clear error if empty or the
+  dump was taken without `--get-master-status`).
+- Execute, in order, on a single connection:
+  1. `RESET MASTER` (MySQL ≤ 8.0 / 5.7) or `RESET BINARY LOGS AND GTIDS`
+     (8.4+) — version-detect the same way `taskmanager.go` does
+     (`mysqlAtLeast`).
+  2. `SET GLOBAL gtid_purged = '<set>'`.
+- Safety requirements:
+  - Refuse to run if `SHOW REPLICA STATUS` returns rows with running threads
+    (target is already a replica) unless `--force`.
+  - Errant-transaction gate: before touching GTID state, verify the target's
+    `gtid_executed` is a subset of the dump's `gtid_set`
+    (`GTID_SUBTRACT(target, dump) = ''`). This is the same check
+    [go-gtids](https://github.com/ChaosHour/go-gtids) performs between two
+    live servers — reuse its logic (see `pkg/gtids` in that repo). Keep the
+    fix/remediation out of go-load: on failure, refuse and point the operator
+    at go-gtids.
+  - Refuse if the target has other databases with data beyond what was just
+    loaded? At minimum warn: `RESET MASTER` destroys the target's binlog
+    history.
+  - Requires `SUPER`/`SYSTEM_VARIABLES_ADMIN`; detect the privilege error and
+    print a Cloud SQL/RDS-specific hint (use provider external replication API).
+  - MySQL 8.0+ allows *appending* to `gtid_purged` with a leading `+`; consider
+    `--set-gtid-purged=append` for partial-seed scenarios.
+
+### 2. `go-load --skip-binlog` — ✅ DONE (2026-07-03)
+
+Implemented: `SET SQL_LOG_BIN=0` is applied in `doLoadFile` alongside the other
+per-connection session settings, which covers every connection the load uses
+(each file gets a dedicated `db.Conn`). Fails hard on error — a
+partially-logged load is worse than an aborted one — and error 1227 gets a
+Cloud SQL/RDS-specific message.
+
+Validated 2026-07-03 against a live MySQL 8.0.43 primary→replica pair
+(`gtid_mode=ON`): load with the flag left the replica untouched and
+`gtid_executed` byte-identical; the same load without the flag replicated all
+rows downstream. Post-test errant-GTID check via go-gtids: clean.
+
+Remaining interaction to honour in item 1: with `--skip-binlog` the load adds
+nothing to `gtid_executed`, so `RESET MASTER` may be skippable when the target
+started empty. `--set-gtid-purged` should check `@@gtid_executed` at runtime
+instead of assuming.
+
+### 3. `go-load --change-source` / emit a helper script at dump time
+
+Two options (pick one, or both):
+
+- **Load-time:** `go-load --change-source --source-host ... --source-user ...
+  --source-password-env ...` runs `CHANGE REPLICATION SOURCE TO ...
+  SOURCE_AUTO_POSITION=1` + `START REPLICA` after `--set-gtid-purged`.
+  Version-gate the syntax (`CHANGE MASTER TO` + `MASTER_AUTO_POSITION` on 5.7,
+  `START SLAVE` on 5.7).
+- **Dump-time:** with `--get-master-status`, also write
+  `change-replication-source.sql` containing a ready-to-edit template with the
+  captured coordinates filled in (both GTID auto-position and file/position
+  variants, one commented out). Zero risk, no new privileges, helps the manual
+  workflow immediately. **Recommended first step.**
+
+### 4. Rename `master-data.sql` / `slave-data.sql` → `.txt`
+
+The files are plain-text reports (`Master File: binlog.000042`), not executable
+SQL. The `.sql` extension invites piping them into `mysql` (syntax error) and
+forces the skip-list in `importer.go findFiles`. Renaming to `master-data.txt` /
+`slave-data.txt`:
+
+- Keep reading both names in `findFiles` skip logic for old dumps.
+- Alternatively make them valid SQL comments (`-- Master File: ...`) like
+  mydumper's metadata file — backwards compatible with the current extension.
+
+### 5. MariaDB GTID support on restore
+
+`getSlaveData` already reads `Gtid_Slave_Pos`, but seeding a MariaDB replica
+needs `SET GLOBAL gtid_slave_pos = '...'` +
+`CHANGE MASTER TO ... , MASTER_USE_GTID = slave_pos` — different from MySQL.
+`metadata.json` currently only has the MySQL-style `gtid_set` field from
+`SHOW MASTER STATUS`; MariaDB's equivalent is `gtid_binlog_pos` /
+`gtid_current_pos`. Needs:
+
+- Capture `@@gtid_binlog_pos` on MariaDB in `getMasterData`.
+- A `flavor` field in `metadata.json` (`mysql` | `mariadb`) so go-load can pick
+  the right restore statements.
+
+### 6. Test strategy
+
+- Unit: metadata round-trip with/without `gtid_set`; version gating of
+  `RESET MASTER` vs `RESET BINARY LOGS AND GTIDS` statement selection.
+- Integration (requires MySQL, extend `make test-integration`):
+  1. Start two containers (primary with `gtid_mode=ON`, empty replica).
+  2. Write rows, dump primary with `--get-master-status`.
+  3. Write more rows on the primary *after* the dump.
+  4. `go-load` into the replica, apply `--set-gtid-purged` + `--change-source`.
+  5. Assert replica catches up and `CHECKSUM TABLE` matches on both; run
+     [go-gtids](https://github.com/ChaosHour/go-gtids) source→replica and
+     assert "No Errant Transactions".
+  - Repeat with `gtid_mode=OFF` using file/position.
+- Integration for `--skip-binlog`: load on a primary with a downstream replica,
+  assert the replica did **not** receive the rows and `gtid_executed` on the
+  primary is unchanged.
+
+## Suggested implementation order
+
+1. ~~`go-load --skip-binlog` (item 2)~~ — ✅ done 2026-07-03.
+2. Dump-time `change-replication-source.sql` template (item 3b) — small, safe,
+   immediately useful.
+3. `go-load --set-gtid-purged` (item 1).
+4. `go-load --change-source` (item 3a).
+5. File rename (item 4) and MariaDB flavor support (item 5) as follow-ups.

--- a/internal/load/importer.go
+++ b/internal/load/importer.go
@@ -32,11 +32,19 @@ type Importer struct {
 	db         *sql.DB
 	workers    int
 	skipSchema bool
+	skipBinlog bool
 }
 
 // New creates an Importer. Call Close() when done.
 func New(db *sql.DB, workers int, skipSchema bool) *Importer {
 	return &Importer{db: db, workers: workers, skipSchema: skipSchema}
+}
+
+// SetSkipBinlog makes every load connection run SET SQL_LOG_BIN=0, so the
+// restore is written to the target only — not to its binlog, its replicas, or
+// its GTID history. Requires SUPER or SYSTEM_VARIABLES_ADMIN on the target.
+func (imp *Importer) SetSkipBinlog(v bool) {
+	imp.skipBinlog = v
 }
 
 // Close releases the underlying database connection pool.
@@ -221,6 +229,20 @@ func (imp *Importer) doLoadFile(ctx context.Context, path string) error {
 	} {
 		if _, err := conn.ExecContext(ctx, set); err != nil {
 			return fmt.Errorf("%s: %w", set, err)
+		}
+	}
+
+	// SQL_LOG_BIN is session-scoped, so it must be set on every connection the
+	// load uses — a connection that misses it would silently replicate its
+	// files downstream. Fail hard rather than degrade to a partially-logged load.
+	if imp.skipBinlog {
+		if _, err := conn.ExecContext(ctx, "SET SQL_LOG_BIN=0"); err != nil {
+			var me *mysql.MySQLError
+			if errors.As(err, &me) && me.Number == 1227 {
+				return fmt.Errorf("SET SQL_LOG_BIN=0 requires SUPER or SYSTEM_VARIABLES_ADMIN "+
+					"(not granted on Cloud SQL/RDS — drop --skip-binlog there): %w", err)
+			}
+			return fmt.Errorf("SET SQL_LOG_BIN=0: %w", err)
 		}
 	}
 

--- a/internal/load/skipbinlog_test.go
+++ b/internal/load/skipbinlog_test.go
@@ -1,0 +1,228 @@
+package load
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// ── fake driver ──────────────────────────────────────────────────────────────
+// A minimal database/sql driver that records every executed statement and can
+// be told to fail statements matching a prefix. Lets us test doLoadFile's
+// session setup (SET SQL_LOG_BIN=0 and friends) without a MySQL server.
+
+type stmtRecorder struct {
+	mu     sync.Mutex
+	stmts  []string
+	failOn string // statement prefix to fail
+	err    error  // error returned for failOn matches
+}
+
+func (r *stmtRecorder) record(q string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stmts = append(r.stmts, q)
+	if r.failOn != "" && strings.HasPrefix(q, r.failOn) {
+		return r.err
+	}
+	return nil
+}
+
+func (r *stmtRecorder) executed() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.stmts))
+	copy(out, r.stmts)
+	return out
+}
+
+type fakeDriver struct{ rec *stmtRecorder }
+
+func (d *fakeDriver) Open(_ string) (driver.Conn, error) { return &fakeConn{rec: d.rec}, nil }
+
+type fakeConn struct{ rec *stmtRecorder }
+
+func (c *fakeConn) Prepare(query string) (driver.Stmt, error) {
+	return &fakeStmt{conn: c, query: query}, nil
+}
+func (c *fakeConn) Close() error              { return nil }
+func (c *fakeConn) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
+
+// ExecContext is what conn.ExecContext uses directly.
+func (c *fakeConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	if err := c.rec.record(query); err != nil {
+		return nil, err
+	}
+	return driver.ResultNoRows, nil
+}
+
+type fakeStmt struct {
+	conn  *fakeConn
+	query string
+}
+
+func (s *fakeStmt) Close() error  { return nil }
+func (s *fakeStmt) NumInput() int { return -1 }
+func (s *fakeStmt) Exec(_ []driver.Value) (driver.Result, error) {
+	if err := s.conn.rec.record(s.query); err != nil {
+		return nil, err
+	}
+	return driver.ResultNoRows, nil
+}
+func (s *fakeStmt) Query(_ []driver.Value) (driver.Rows, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+var fakeDriverSeq int64
+
+// newFakeDB registers a fresh fake driver instance (sql.Register panics on
+// duplicate names, so each call gets a unique name) and returns the DB plus
+// its statement recorder.
+func newFakeDB(t *testing.T) (*sql.DB, *stmtRecorder) {
+	t.Helper()
+	rec := &stmtRecorder{}
+	name := fmt.Sprintf("fake-load-%d", atomic.AddInt64(&fakeDriverSeq, 1))
+	sql.Register(name, &fakeDriver{rec: rec})
+	db, err := sql.Open(name, "dsn-ignored")
+	if err != nil {
+		t.Fatalf("open fake db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db, rec
+}
+
+// writeTempSQL creates a small dump-style data file and returns its path.
+func writeTempSQL(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "data.sql")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write temp sql: %v", err)
+	}
+	return path
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+func TestDoLoadFile_DefaultDoesNotTouchBinlog(t *testing.T) {
+	db, rec := newFakeDB(t)
+	imp := New(db, 1, false)
+
+	path := writeTempSQL(t, "INSERT INTO t (id) VALUES (1);\n")
+	if err := imp.doLoadFile(context.Background(), path); err != nil {
+		t.Fatalf("doLoadFile: %v", err)
+	}
+
+	for _, q := range rec.executed() {
+		if strings.Contains(q, "SQL_LOG_BIN") {
+			t.Errorf("binlog statement executed without --skip-binlog: %q", q)
+		}
+	}
+}
+
+func TestDoLoadFile_SkipBinlogSetBeforeData(t *testing.T) {
+	db, rec := newFakeDB(t)
+	imp := New(db, 1, false)
+	imp.SetSkipBinlog(true)
+
+	path := writeTempSQL(t, "INSERT INTO t (id) VALUES (1);\nINSERT INTO t (id) VALUES (2);\n")
+	if err := imp.doLoadFile(context.Background(), path); err != nil {
+		t.Fatalf("doLoadFile: %v", err)
+	}
+
+	stmts := rec.executed()
+	binlogIdx, firstDataIdx := -1, -1
+	for i, q := range stmts {
+		if q == "SET SQL_LOG_BIN=0" && binlogIdx == -1 {
+			binlogIdx = i
+		}
+		if strings.HasPrefix(q, "INSERT") && firstDataIdx == -1 {
+			firstDataIdx = i
+		}
+	}
+	if binlogIdx == -1 {
+		t.Fatalf("SET SQL_LOG_BIN=0 never executed; statements: %v", stmts)
+	}
+	if firstDataIdx == -1 {
+		t.Fatalf("no data statement executed; statements: %v", stmts)
+	}
+	if binlogIdx > firstDataIdx {
+		t.Errorf("SET SQL_LOG_BIN=0 executed at %d, AFTER first data statement at %d — data would be binlogged", binlogIdx, firstDataIdx)
+	}
+}
+
+func TestDoLoadFile_SkipBinlogPrivilegeErrorGetsHint(t *testing.T) {
+	db, rec := newFakeDB(t)
+	rec.failOn = "SET SQL_LOG_BIN=0"
+	rec.err = &mysql.MySQLError{Number: 1227, Message: "Access denied; you need (at least one of) the SUPER, SYSTEM_VARIABLES_ADMIN privilege(s)"}
+
+	imp := New(db, 1, false)
+	imp.SetSkipBinlog(true)
+
+	path := writeTempSQL(t, "INSERT INTO t (id) VALUES (1);\n")
+	err := imp.doLoadFile(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected error when SET SQL_LOG_BIN=0 is denied, got nil")
+	}
+	if !strings.Contains(err.Error(), "SUPER or SYSTEM_VARIABLES_ADMIN") {
+		t.Errorf("error 1227 should carry the privilege hint, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--skip-binlog") {
+		t.Errorf("error 1227 should mention the flag to drop, got: %v", err)
+	}
+	// The load must abort: no data statement may run after the failed SET.
+	for _, q := range rec.executed() {
+		if strings.HasPrefix(q, "INSERT") {
+			t.Errorf("data statement executed after SET SQL_LOG_BIN=0 failed — partially-logged load: %q", q)
+		}
+	}
+}
+
+func TestDoLoadFile_SkipBinlogGenericErrorAborts(t *testing.T) {
+	db, rec := newFakeDB(t)
+	rec.failOn = "SET SQL_LOG_BIN=0"
+	rec.err = &mysql.MySQLError{Number: 1193, Message: "Unknown system variable"}
+
+	imp := New(db, 1, false)
+	imp.SetSkipBinlog(true)
+
+	path := writeTempSQL(t, "INSERT INTO t (id) VALUES (1);\n")
+	err := imp.doLoadFile(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "SET SQL_LOG_BIN=0") {
+		t.Errorf("error should identify the failing statement, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "SUPER or SYSTEM_VARIABLES_ADMIN") {
+		t.Errorf("non-1227 error must not get the privilege hint, got: %v", err)
+	}
+}
+
+func TestDoLoadFile_SessionSettingsAlwaysApplied(t *testing.T) {
+	db, rec := newFakeDB(t)
+	imp := New(db, 1, false)
+	imp.SetSkipBinlog(true)
+
+	path := writeTempSQL(t, "INSERT INTO t (id) VALUES (1);\n")
+	if err := imp.doLoadFile(context.Background(), path); err != nil {
+		t.Fatalf("doLoadFile: %v", err)
+	}
+
+	want := []string{"SET FOREIGN_KEY_CHECKS=0", "SET UNIQUE_CHECKS=0"}
+	got := rec.executed()
+	for _, w := range want {
+		if !slices.Contains(got, w) {
+			t.Errorf("session setting %q not executed; statements: %v", w, got)
+		}
+	}
+}

--- a/test/docker-compose.versions.yml
+++ b/test/docker-compose.versions.yml
@@ -1,0 +1,80 @@
+# Multi-version MySQL matrix for go-dump/go-load integration testing.
+#
+# Ports are deliberately non-standard so this stack can run alongside an
+# existing local MySQL (3306/3307):
+#   5.7  → 127.0.0.1:33057
+#   8.0  → 127.0.0.1:33080
+#   8.4  → 127.0.0.1:33084
+#   9    → 127.0.0.1:33090
+#
+# All servers run with gtid_mode=ON so --get-master-status captures a GTID set.
+#
+# Usage:
+#   make test-versions-up     # start all four (first run pulls images)
+#   make test-versions        # run the matrix test script
+#   make test-versions-down   # stop and remove (volumes included)
+#
+# Note: mysql:5.7 has no arm64 image — platform: linux/amd64 makes it run
+# under emulation on Apple Silicon (Rosetta must be enabled in Docker Desktop).
+
+x-mysql-env: &mysql-env
+  MYSQL_ROOT_PASSWORD: s3cr3t
+
+x-healthcheck: &mysql-health
+  test: ["CMD", "mysqladmin", "ping", "-uroot", "-ps3cr3t", "--silent"]
+  interval: 2s
+  timeout: 5s
+  retries: 60
+
+services:
+  mysql57:
+    image: mysql:5.7
+    platform: linux/amd64
+    container_name: godump-mysql57
+    environment: *mysql-env
+    ports:
+      - "127.0.0.1:33057:3306"
+    command:
+      - --server-id=57
+      - --log-bin=binlog
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_general_ci
+    healthcheck: *mysql-health
+
+  mysql80:
+    image: mysql:8.0
+    container_name: godump-mysql80
+    environment: *mysql-env
+    ports:
+      - "127.0.0.1:33080:3306"
+    command:
+      - --server-id=80
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+    healthcheck: *mysql-health
+
+  mysql84:
+    image: mysql:8.4
+    container_name: godump-mysql84
+    environment: *mysql-env
+    ports:
+      - "127.0.0.1:33084:3306"
+    command:
+      - --server-id=84
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+    healthcheck: *mysql-health
+
+  mysql9:
+    image: mysql:9
+    container_name: godump-mysql9
+    environment: *mysql-env
+    ports:
+      - "127.0.0.1:33090:3306"
+    command:
+      - --server-id=90
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+    healthcheck: *mysql-health

--- a/test/test-versions.sh
+++ b/test/test-versions.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Multi-version integration matrix for go-dump/go-load.
+#
+# For each MySQL version (5.7, 8.0, 8.4, 9) started by
+# test/docker-compose.versions.yml, this script:
+#   1. seeds a test database (PK table, quotes/unicode/datetime data)
+#   2. dumps it with --get-master-status --checksum and asserts a GTID set
+#      was captured
+#   3. drops the database and restores it with go-load --verify
+#   4. asserts the row count survived the round trip
+#   5. truncates, reloads with --skip-binlog, and asserts gtid_executed is
+#      byte-identical (the load left no trace in the binlog/GTID history)
+#
+# Usage: ./test/test-versions.sh [version ...]   (default: 57 80 84 9)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSIONS=("${@:-57 80 84 9}")
+[[ $# -eq 0 ]] && VERSIONS=(57 80 84 9)
+
+# macOS ships bash 3.2 (no associative arrays) — use a function instead.
+port_for() {
+  case "$1" in
+    57) echo 33057 ;;
+    80) echo 33080 ;;
+    84) echo 33084 ;;
+    9)  echo 33090 ;;
+    *)  echo "unknown version: $1" >&2; return 1 ;;
+  esac
+}
+
+GODUMP=./bin/go-dump
+GOLOAD=./bin/go-load
+OUTROOT=./test/matrix-out
+PASS=() FAIL=()
+
+msql() { # msql <version> <sql>  — runs inside the container, silences pw warning
+  docker exec "godump-mysql$1" mysql -uroot -ps3cr3t -N -e "$2" 2>/dev/null
+}
+
+seed() {
+  msql "$1" "
+    DROP DATABASE IF EXISTS matrix;
+    CREATE DATABASE matrix;
+    CREATE TABLE matrix.items (
+      id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      name VARCHAR(64) NOT NULL,
+      note VARCHAR(64),
+      created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    INSERT INTO matrix.items (name, note) VALUES
+      ('plain', NULL),
+      ('O''Brien; quotes', 'semi;colon'),
+      ('unicode-Ω-日本語', 'high \\\\ backslash');
+    INSERT INTO matrix.items (name, note)
+      SELECT CONCAT('row-', t1.n + t2.n*10 + t3.n*100), 'bulk'
+      FROM (SELECT 0 n UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+            UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
+           (SELECT 0 n UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+            UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
+           (SELECT 0 n UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4) t3;"
+}
+
+run_version() {
+  local v=$1 dest port
+  port=$(port_for "$v")
+  dest="$OUTROOT/mysql$v"
+  rm -rf "$dest"
+
+  echo "── MySQL $v (port $port) ─────────────────────────────────────────"
+  local server_version
+  server_version=$(msql "$v" "SELECT VERSION();")
+  echo "   server: $server_version"
+
+  seed "$v"
+  local rows_before
+  rows_before=$(msql "$v" "SELECT COUNT(*) FROM matrix.items;")
+
+  # 1. Dump with GTID capture + checksums
+  $GODUMP --mysql-host 127.0.0.1 --mysql-port "$port" \
+    --mysql-user root --mysql-password s3cr3t \
+    --databases matrix --destination "$dest" \
+    --threads 2 --chunk-size 100 \
+    --get-master-status --checksum --add-drop-table \
+    --quiet --execute
+
+  grep -q '"gtid_set": "..*"' "$dest/metadata.json" \
+    || { echo "   FAIL: no gtid_set in metadata.json"; return 1; }
+
+  # 2. Drop and restore
+  msql "$v" "DROP DATABASE matrix;"
+  $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
+    --directory "$dest" --workers 2 --verify --quiet
+
+  local rows_after
+  rows_after=$(msql "$v" "SELECT COUNT(*) FROM matrix.items;")
+  [[ "$rows_after" == "$rows_before" ]] \
+    || { echo "   FAIL: rows $rows_before -> $rows_after after restore"; return 1; }
+
+  # 3. --skip-binlog: reload must leave gtid_executed untouched
+  msql "$v" "TRUNCATE TABLE matrix.items;"
+  local gtid_before gtid_after
+  gtid_before=$(msql "$v" "SELECT @@global.gtid_executed;")
+  $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
+    --directory "$dest" --workers 2 --data-only --skip-binlog --quiet
+  gtid_after=$(msql "$v" "SELECT @@global.gtid_executed;")
+
+  [[ "$gtid_before" == "$gtid_after" ]] \
+    || { echo "   FAIL: --skip-binlog changed gtid_executed"; return 1; }
+  rows_after=$(msql "$v" "SELECT COUNT(*) FROM matrix.items;")
+  [[ "$rows_after" == "$rows_before" ]] \
+    || { echo "   FAIL: rows $rows_before -> $rows_after after skip-binlog reload"; return 1; }
+
+  msql "$v" "DROP DATABASE matrix;"
+  echo "   PASS: dump+gtid, restore+verify, skip-binlog ($rows_before rows)"
+}
+
+[[ -x $GODUMP && -x $GOLOAD ]] || { echo "Build first: make build && make build-go-load"; exit 1; }
+
+for v in ${VERSIONS[@]}; do
+  if run_version "$v"; then PASS+=("$v"); else FAIL+=("$v"); fi
+done
+
+echo "──────────────────────────────────────────────────────────────────"
+echo "PASS: ${PASS[*]:-none}   FAIL: ${FAIL[*]:-none}"
+[[ ${#FAIL[@]} -eq 0 ]]


### PR DESCRIPTION
## Summary

- **`go-load --skip-binlog`**: runs `SET SQL_LOG_BIN=0` on every load connection so a restore is not written to the target's binlog, replicated downstream, or added to `gtid_executed`. Fails hard rather than continuing a partially-logged load; privilege error 1227 gets a SUPER/SYSTEM_VARIABLES_ADMIN hint for Cloud SQL/RDS users. Also removes the need for `RESET MASTER` when seeding a fresh replica.
- **README — "Replication and GTIDs"**: replica-seeding recipe (dump with `--get-master-status` → load → `gtid_purged` → `CHANGE REPLICATION SOURCE TO`, with 5.7 through 8.4+/9 syntax), replication-safe table repopulation, a step-through [go-gtids](https://github.com/ChaosHour/go-gtids) errant-transaction guide, and a new **Limitations** section (base tables only — no views/triggers/routines/events; grants; charset caveats).
- **`docs/GTID-REPLICATION.md`**: current state + roadmap for full seeding automation (`--set-gtid-purged`, `--change-source`, MariaDB flavor support) with effort notes and test strategy.
- **Multi-version test matrix**: `test/docker-compose.versions.yml` starts MySQL 5.7/8.0/8.4/9 with `gtid_mode=ON` on ports 33057/33080/33084/33090 (coexists with a local 3306); `test/test-versions.sh` runs dump-with-GTID-capture → drop-database → restore → checksum verify → `--skip-binlog` GTID-invariance per version. New Makefile targets `test-versions-up` / `test-versions` / `test-versions-down`.
- **Makefile fix**: `test-unit` never ran `internal/load` tests (the dump-name whitelist filtered them all out); load tests now run unfiltered.

## Testing

- New unit tests for `--skip-binlog` using a fake `database/sql` driver (no MySQL required): binlog-off ordering before any data statement, abort-on-failure, 1227 hint, session settings. 48 tests passing.
- Version matrix run: **PASS on 5.7.44, 8.0.45, 8.4.10, and 9.7.1** — first verification that the `SHOW BINARY LOG STATUS` gating carries into MySQL 9.x.
- Live validation against an 8.0.43 primary→replica pair with running replication: `--skip-binlog` load left the replica untouched and `gtid_executed` byte-identical; the same load without the flag replicated normally; go-gtids errant check clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)