### PR TITLE
Automate replica seeding: --set-gtid-purged and change-replication-source.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ make test-versions-down    # tear down (removes volumes)
 
 The matrix (`test/docker-compose.versions.yml` + `test/test-versions.sh`)
 verifies, per version: GTID capture in `metadata.json`, a full
-drop-database→restore→checksum-verify round trip, and that
-`go-load --skip-binlog` leaves `gtid_executed` byte-identical.
-MySQL 5.7 runs under amd64 emulation on Apple Silicon (Rosetta).
+drop-database→restore→checksum-verify round trip, `go-load --skip-binlog`
+leaving `gtid_executed` byte-identical, the `change-replication-source.sql`
+template, and `--set-gtid-purged` (both the errant-transaction refusal and the
+reset→seed success path). MySQL 5.7 runs under amd64 emulation on Apple
+Silicon (Rosetta).
 
 The `VERSION` file controls the embedded version string. Override at build time:
 
@@ -208,7 +210,7 @@ go-dump --ini-file /etc/go-dump/primary.ini --databases myapp --destination /bac
 | `--compress` | false | Gzip-compress output files (`.sql.gz`). |
 | `--compress-level` | 1 | Compression level 1 (fastest) to 9 (smallest). |
 | `--checksum` | false | Run `CHECKSUM TABLE` after the dump and write `checksums.txt`. |
-| `--get-master-status` | false | Record binlog file/position and GTID set in `master-data.sql` and `metadata.json`. |
+| `--get-master-status` | false | Record binlog file/position and GTID set in `master-data.sql` and `metadata.json`, and write the `change-replication-source.sql` setup template. |
 | `--get-slave-status` | false | Record replica status in `slave-data.sql`. |
 | `--output-chunk-size` | 0 | Rows per INSERT statement (0 = same as chunk-size). |
 
@@ -477,6 +479,7 @@ A dump of `myapp.orders` with 4 threads produces:
 /backups/myapp/
 ├── metadata.json                          # dump metadata (MySQL version, binlog, table status)
 ├── master-data.sql                        # binlog position / GTID set (--get-master-status)
+├── change-replication-source.sql          # ready-to-edit replica setup script (--get-master-status)
 ├── slave-data.sql                         # replica status (--get-slave-status)
 ├── checksums.txt                          # CHECKSUM TABLE results (--checksum)
 ├── myapp-schema-create.sql                # CREATE DATABASE IF NOT EXISTS (one per schema)
@@ -606,28 +609,27 @@ This records in `/backups/seed/metadata.json`:
 and the same values in human-readable form in `master-data.sql` (a text report,
 not executable SQL — go-load skips it automatically).
 
+The dump also writes **`change-replication-source.sql`** — a ready-to-edit
+script with the captured coordinates already filled in (GTID auto-position,
+5.7 syntax, and file/position variants). go-load never executes it; it is for
+you.
+
 Restore onto the new replica, then configure replication:
 
 ```bash
-# 1. Load the data (go-load prints the recorded binlog/GTID coordinates).
-#    --skip-binlog keeps the load out of the replica's own binlog/GTID history,
-#    so gtid_purged can be set afterwards without RESET MASTER.
+# 1. Load the data and hand over the GTID state in one step:
+#    --skip-binlog     keeps the load out of the replica's own GTID history
+#    --set-gtid-purged sets gtid_purged to the dump's snapshot GTID set
+#                      (from metadata.json), with safety checks — it refuses
+#                      on running replicas and on errant transactions.
 go-load --host replica1 --user root --password ... \
-  --directory /backups/seed --workers 8 --verify --skip-binlog
+  --directory /backups/seed --workers 8 --verify \
+  --skip-binlog --set-gtid-purged
 ```
 
 ```sql
--- 2. On the replica: set gtid_purged to the dump's snapshot GTID set
---    (from metadata.json "gtid_set").
---    gtid_purged can only be set while gtid_executed is empty. With
---    --skip-binlog above (and a fresh instance), it already is. If the load
---    ran WITHOUT --skip-binlog, clear the local GTID history first:
---      RESET MASTER;                   -- MySQL <= 8.0 / 5.7
---      RESET BINARY LOGS AND GTIDS;    -- MySQL 8.4+
---    (destructive: wipes the replica's own binlogs — never run on the primary)
-SET GLOBAL gtid_purged = '3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123';
-
--- 3. Point the replica at the primary using auto-positioning.
+-- 2. Point the replica at the primary: edit SOURCE_USER / SOURCE_PASSWORD in
+--    the dump's change-replication-source.sql and run it, or by hand:
 CHANGE REPLICATION SOURCE TO
   SOURCE_HOST = 'primary1.db.internal',
   SOURCE_PORT = 3306,
@@ -636,11 +638,28 @@ CHANGE REPLICATION SOURCE TO
   SOURCE_AUTO_POSITION = 1;         -- MySQL 8.0.23+; use CHANGE MASTER TO / MASTER_AUTO_POSITION=1 on 5.7
 START REPLICA;                      -- START SLAVE on 5.7
 
--- 4. Verify
+-- 3. Verify
 SHOW REPLICA STATUS\G               -- Replica_IO_Running / Replica_SQL_Running: Yes
 ```
 
 Then prove the seed is clean with go-gtids — see the step-through guide below.
+
+**What `--set-gtid-purged` does, and its guard rails:**
+
+- Reads `gtid_set` from the dump's `metadata.json` (fails up front if the dump
+  was taken without `--get-master-status`).
+- Requires `gtid_mode=ON` on the target.
+- **Refuses** if the target has a *running* replication channel (always), or a
+  configured-but-stopped one (unless `--force`).
+- If the target's `gtid_executed` is empty (the `--skip-binlog` path, or a
+  fresh instance): just sets `gtid_purged`. No reset, no `--force` needed.
+- If `gtid_executed` is non-empty but a subset of the dump's set (e.g. the
+  load itself was binlogged): requires `--force`, then runs `RESET MASTER`
+  (8.4+/9: `RESET BINARY LOGS AND GTIDS`) before setting `gtid_purged` —
+  destructive to the target's own binlog history, hence the flag.
+- If the target has transactions **beyond** the dump's set: refuses, even with
+  `--force` — that's errant-transaction territory; inspect with go-gtids.
+- Verifies afterwards that `gtid_executed` equals the dump's set exactly.
 
 ### Verifying a replica with go-gtids (errant transaction check)
 

--- a/cmd/go-load/main.go
+++ b/cmd/go-load/main.go
@@ -29,18 +29,20 @@ func main() {
 		socket   string
 		database string
 
-		directory  string
-		file       string
-		pattern    string
-		workers    int
-		dataOnly   bool
-		skipBinlog bool
-		verify     bool
-		resume     bool
-		quiet      bool
-		debug      bool
-		iniFile    string
-		flagVersion bool
+		directory     string
+		file          string
+		pattern       string
+		workers       int
+		dataOnly      bool
+		skipBinlog    bool
+		setGtidPurged bool
+		force         bool
+		verify        bool
+		resume        bool
+		quiet         bool
+		debug         bool
+		iniFile       string
+		flagVersion   bool
 	)
 
 	flag.StringVar(&host, "host", "localhost", "MySQL host")
@@ -55,6 +57,8 @@ func main() {
 	flag.IntVar(&workers, "workers", 4, "Number of parallel workers for data files")
 	flag.BoolVar(&dataOnly, "data-only", false, "Skip schema (definition) files; load data files only")
 	flag.BoolVar(&skipBinlog, "skip-binlog", false, "Run SET SQL_LOG_BIN=0 on every load connection so the restore is not written to the target's binlog or replicated downstream. Requires SUPER or SYSTEM_VARIABLES_ADMIN.")
+	flag.BoolVar(&setGtidPurged, "set-gtid-purged", false, "After the load, set the target's gtid_purged to the dump's captured GTID set (from metadata.json) so it can replicate with SOURCE_AUTO_POSITION=1. Refuses on active replicas or errant transactions.")
+	flag.BoolVar(&force, "force", false, "With --set-gtid-purged: allow acting on a stopped replication channel, and allow RESET MASTER / RESET BINARY LOGS AND GTIDS when the target's gtid_executed is non-empty (destroys the target's binlog history).")
 	flag.BoolVar(&verify, "verify", false, "Verify checksums after loading (requires checksums.txt in --directory)")
 	flag.BoolVar(&resume, "resume", false, "Resume a previous load: skip files recorded in load-state.json")
 	flag.BoolVar(&quiet, "quiet", false, "Suppress INFO messages")
@@ -94,6 +98,9 @@ func main() {
 	if file == "" && directory == "" {
 		log.Fatal("Specify --file or --directory. Use --help for usage.")
 	}
+	if setGtidPurged && directory == "" {
+		log.Fatal("--set-gtid-purged requires --directory (the GTID set comes from the dump's metadata.json).")
+	}
 
 	db, err := connect(host, port, user, password, socket, database)
 	if err != nil {
@@ -123,12 +130,23 @@ func main() {
 
 	if directory != "" {
 		// Log useful context from the source dump's metadata if present.
-		if meta, err := dump.LoadDumpMetadata(directory); err == nil {
+		meta, metaErr := dump.LoadDumpMetadata(directory)
+		if metaErr == nil {
 			log.Infof("Source: MySQL %s on %s, dump status: %s",
 				meta.MySQLVersion, meta.MySQLHost, meta.Status)
 			if meta.BinlogFile != "" {
 				log.Infof("Binlog position: %s:%d  GTID: %s",
 					meta.BinlogFile, meta.BinlogPosition, meta.GTIDSet)
+			}
+		}
+		if setGtidPurged {
+			// Fail before loading anything, not after: a missing GTID set means
+			// the dump cannot seed a replica at all.
+			if metaErr != nil {
+				log.Fatalf("--set-gtid-purged: cannot read metadata.json: %v", metaErr)
+			}
+			if meta.GTIDSet == "" {
+				log.Fatal("--set-gtid-purged: metadata.json has no gtid_set — the dump was taken without --get-master-status, or the source has no GTIDs.")
 			}
 		}
 
@@ -151,6 +169,13 @@ func main() {
 				log.Fatalf("Checksum verification failed:\n  %v", err)
 			}
 			log.Info("Checksum verification passed.")
+		}
+
+		if setGtidPurged {
+			log.Info("Applying the dump's GTID set to the target (--set-gtid-purged)...")
+			if err := load.ApplyGTIDPurged(ctx, db, meta.GTIDSet, force); err != nil {
+				log.Fatalf("%v", err)
+			}
 		}
 	} else {
 		if err := imp.ImportFile(ctx, file); err != nil {

--- a/docs/GTID-REPLICATION.md
+++ b/docs/GTID-REPLICATION.md
@@ -26,50 +26,51 @@ to make replica seeding a one-command operation.
   `SET @@GLOBAL.GTID_PURGED`, no `CHANGE MASTER`. Restores are replication-safe
   by construction — the mysqldump `gtid_purged` footgun does not exist here.
 
-### Load side — partial
+### Load side — nearly complete
 
 - `go-load` reads `metadata.json` and **logs** the source binlog/GTID
   coordinates (`cmd/go-load/main.go`).
-- `master-data.*` / `slave-data.*` are correctly excluded from loadable files
-  (`internal/load/importer.go`, `findFiles`).
+- `master-data.*` / `slave-data.*` / `change-replication-source.*` are
+  correctly excluded from loadable files (`internal/load/importer.go`,
+  `findFiles`).
 - `go-load --skip-binlog` runs `SET SQL_LOG_BIN=0` on every load connection
   (`internal/load/importer.go`, `doLoadFile`) — loads without replicating
   downstream or touching `gtid_executed`. Aborts (rather than degrading) if the
   privilege is missing, with a Cloud SQL/RDS hint on error 1227.
-- Everything after the data load (`gtid_purged`,
-  `CHANGE REPLICATION SOURCE TO`, `START REPLICA`) is **manual** — documented in
-  README "Replication and GTIDs".
+- `go-load --set-gtid-purged` applies the dump's GTID set to the target after
+  the load, with errant-transaction and running-replica guards
+  (`internal/load/gtid.go`) — see item 1 below.
+- Only `CHANGE REPLICATION SOURCE TO` + `START REPLICA` remain manual, and the
+  dump ships a filled-in template (`change-replication-source.sql`) for them.
 
 ## Gaps / planned features
 
-### 1. `go-load --set-gtid-purged` (highest value)
+### 1. `go-load --set-gtid-purged` — ✅ DONE (2026-07-03)
 
-Automate the GTID handoff after a seed restore.
+Implemented in `internal/load/gtid.go` (`ApplyGTIDPurged`), wired to run after
+a successful directory load (and after `--verify`). Behaviour:
 
-- Read `gtid_set` from `metadata.json` (fail with a clear error if empty or the
-  dump was taken without `--get-master-status`).
-- Execute, in order, on a single connection:
-  1. `RESET MASTER` (MySQL ≤ 8.0 / 5.7) or `RESET BINARY LOGS AND GTIDS`
-     (8.4+) — version-detect the same way `taskmanager.go` does
-     (`mysqlAtLeast`).
-  2. `SET GLOBAL gtid_purged = '<set>'`.
-- Safety requirements:
-  - Refuse to run if `SHOW REPLICA STATUS` returns rows with running threads
-    (target is already a replica) unless `--force`.
-  - Errant-transaction gate: before touching GTID state, verify the target's
-    `gtid_executed` is a subset of the dump's `gtid_set`
-    (`GTID_SUBTRACT(target, dump) = ''`). This is the same check
-    [go-gtids](https://github.com/ChaosHour/go-gtids) performs between two
-    live servers — reuse its logic (see `pkg/gtids` in that repo). Keep the
-    fix/remediation out of go-load: on failure, refuse and point the operator
-    at go-gtids.
-  - Refuse if the target has other databases with data beyond what was just
-    loaded? At minimum warn: `RESET MASTER` destroys the target's binlog
-    history.
-  - Requires `SUPER`/`SYSTEM_VARIABLES_ADMIN`; detect the privilege error and
-    print a Cloud SQL/RDS-specific hint (use provider external replication API).
-  - MySQL 8.0+ allows *appending* to `gtid_purged` with a leading `+`; consider
-    `--set-gtid-purged=append` for partial-seed scenarios.
+- Reads `gtid_set` from `metadata.json`; fails before loading anything if the
+  dump has no GTID set. The set is whitespace-stripped and format-validated
+  before being embedded in SQL.
+- Requires `gtid_mode=ON`; points file/position users at
+  `change-replication-source.sql` otherwise.
+- Refuses on a **running** replication channel always; on a configured-stopped
+  channel unless `--force` (version-gated `SHOW REPLICA STATUS` /
+  `SHOW SLAVE STATUS`).
+- Errant gate: if `GTID_SUBTRACT(gtid_executed, dump_set)` is non-empty,
+  refuses **even with `--force`** and points at go-gtids. Remediation stays
+  out of go-load by design.
+- Empty `gtid_executed` (the `--skip-binlog` path): sets `gtid_purged`
+  directly, no reset, no `--force`. Non-empty subset: requires `--force`, then
+  version-gated `RESET MASTER` / `RESET BINARY LOGS AND GTIDS` (8.4+).
+- Verifies afterwards that `gtid_executed` equals the dump set exactly.
+- Unit-tested against a scripted fake driver (11 tests: refusal paths, version
+  gating, injection attempts); matrix-tested on 5.7.44/8.0.45/8.4.10/9.7.1
+  including the errant-refusal and reset→seed success paths.
+
+Not implemented (still open): `--set-gtid-purged=append` (leading-`+` subset
+append, 8.0+) for partial-seed scenarios.
 
 ### 2. `go-load --skip-binlog` — ✅ DONE (2026-07-03)
 
@@ -91,18 +92,18 @@ instead of assuming.
 
 ### 3. `go-load --change-source` / emit a helper script at dump time
 
-Two options (pick one, or both):
-
-- **Load-time:** `go-load --change-source --source-host ... --source-user ...
-  --source-password-env ...` runs `CHANGE REPLICATION SOURCE TO ...
-  SOURCE_AUTO_POSITION=1` + `START REPLICA` after `--set-gtid-purged`.
-  Version-gate the syntax (`CHANGE MASTER TO` + `MASTER_AUTO_POSITION` on 5.7,
-  `START SLAVE` on 5.7).
-- **Dump-time:** with `--get-master-status`, also write
-  `change-replication-source.sql` containing a ready-to-edit template with the
-  captured coordinates filled in (both GTID auto-position and file/position
-  variants, one commented out). Zero risk, no new privileges, helps the manual
-  workflow immediately. **Recommended first step.**
+- **Dump-time template — ✅ DONE (2026-07-03):** with `--get-master-status`,
+  go-dump writes `change-replication-source.sql`
+  (`taskmanager.go writeChangeSourceTemplate`): captured coordinates filled in,
+  GTID auto-position as the active statements, 5.7 and file/position variants
+  commented. Always plain (never gzipped); go-load's `findFiles` skips it
+  during restore.
+- **Load-time `--change-source` — still open:** `go-load --change-source
+  --source-host ... --source-user ... --source-password-env ...` runs
+  `CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1` + `START REPLICA`
+  after `--set-gtid-purged`, then polls `SHOW REPLICA STATUS` until the
+  threads run or a timeout. Version-gate the syntax (`CHANGE MASTER TO` +
+  `MASTER_AUTO_POSITION`, `START SLAVE` on 5.7).
 
 ### 4. Rename `master-data.sql` / `slave-data.sql` → `.txt`
 
@@ -148,8 +149,9 @@ needs `SET GLOBAL gtid_slave_pos = '...'` +
 ## Suggested implementation order
 
 1. ~~`go-load --skip-binlog` (item 2)~~ — ✅ done 2026-07-03.
-2. Dump-time `change-replication-source.sql` template (item 3b) — small, safe,
-   immediately useful.
-3. `go-load --set-gtid-purged` (item 1).
-4. `go-load --change-source` (item 3a).
-5. File rename (item 4) and MariaDB flavor support (item 5) as follow-ups.
+2. ~~Dump-time `change-replication-source.sql` template (item 3)~~ — ✅ done
+   2026-07-03.
+3. ~~`go-load --set-gtid-purged` (item 1)~~ — ✅ done 2026-07-03.
+4. `go-load --change-source` (item 3, load-time half) — next up.
+5. File rename (item 4), MariaDB flavor support (item 5), and
+   `--set-gtid-purged=append` as follow-ups.

--- a/internal/dump/taskmanager.go
+++ b/internal/dump/taskmanager.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -73,7 +74,7 @@ type TaskManager struct {
 	mySQLCredentials       *MySQLCredentials
 	DumpOptions            *DumpOptions
 	ctx                    context.Context
-	mysqlVersion           [3]int // [major, minor, patch], populated by detectMySQLVersion
+	mysqlVersion           [3]int        // [major, minor, patch], populated by detectMySQLVersion
 	metadata               *DumpMetadata // set via SetMetadata before workers start; nil in dry-run
 
 	// Binlog info captured by getMasterData, written to metadata.
@@ -423,6 +424,69 @@ func (tm *TaskManager) getMasterData() {
 	if err := buffer.Close(); err != nil {
 		log.Fatalf("Error finalising master-data file: %v", err)
 	}
+
+	tm.writeChangeSourceTemplate()
+}
+
+// writeChangeSourceTemplate writes change-replication-source.sql: a
+// ready-to-edit script for pointing a replica seeded from this dump at the
+// dumped server. The captured coordinates are filled in; the operator edits
+// the connection values. Always written uncompressed — it is for humans, and
+// go-load skips it during restore.
+func (tm *TaskManager) writeChangeSourceTemplate() {
+	path := filepath.Join(tm.DestinationDir, "change-replication-source.sql")
+	var b bytes.Buffer
+
+	fmt.Fprintf(&b, "-- go-dump replication setup template\n")
+	fmt.Fprintf(&b, "-- Source: %s (MySQL %s), coordinates captured inside the lock window:\n",
+		tm.mySQLHost.HostName, tm.MySQLVersion())
+	fmt.Fprintf(&b, "--   Binlog file/position: %s:%d\n", tm.BinlogFile, tm.BinlogPosition)
+	if tm.GTIDSet != "" {
+		fmt.Fprintf(&b, "--   Executed GTID set:    %s\n", strings.ReplaceAll(tm.GTIDSet, "\n", ""))
+	}
+	fmt.Fprintf(&b, "--\n")
+	fmt.Fprintf(&b, "-- EDIT the SOURCE_USER / SOURCE_PASSWORD (and host if the replica reaches\n")
+	fmt.Fprintf(&b, "-- the source by another address), then run on the freshly-seeded replica.\n")
+	fmt.Fprintf(&b, "-- go-load does NOT execute this file.\n")
+
+	if tm.GTIDSet != "" {
+		fmt.Fprintf(&b, "--\n")
+		fmt.Fprintf(&b, "-- ── GTID auto-position (recommended; MySQL 8.0.23+ syntax) ──\n")
+		fmt.Fprintf(&b, "-- Prerequisite: gtid_executed must be EMPTY on the replica. Seed with\n")
+		fmt.Fprintf(&b, "-- go-load --skip-binlog (or --set-gtid-purged, which runs the SET below\n")
+		fmt.Fprintf(&b, "-- for you), otherwise run RESET MASTER (8.4+: RESET BINARY LOGS AND GTIDS) first.\n")
+		fmt.Fprintf(&b, "SET GLOBAL gtid_purged = '%s';\n", strings.ReplaceAll(tm.GTIDSet, "\n", ""))
+		fmt.Fprintf(&b, "CHANGE REPLICATION SOURCE TO\n")
+		fmt.Fprintf(&b, "  SOURCE_HOST = '%s',\n", tm.mySQLHost.HostName)
+		fmt.Fprintf(&b, "  SOURCE_PORT = %d,\n", tm.mySQLHost.Port)
+		fmt.Fprintf(&b, "  SOURCE_USER = '<repl_user>',\n")
+		fmt.Fprintf(&b, "  SOURCE_PASSWORD = '<repl_password>',\n")
+		fmt.Fprintf(&b, "  SOURCE_AUTO_POSITION = 1;\n")
+		fmt.Fprintf(&b, "START REPLICA;\n")
+		fmt.Fprintf(&b, "--\n")
+		fmt.Fprintf(&b, "-- ── MySQL 5.7 equivalent ──\n")
+		fmt.Fprintf(&b, "-- SET GLOBAL gtid_purged = '%s';\n", strings.ReplaceAll(tm.GTIDSet, "\n", ""))
+		fmt.Fprintf(&b, "-- CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d,\n", tm.mySQLHost.HostName, tm.mySQLHost.Port)
+		fmt.Fprintf(&b, "--   MASTER_USER='<repl_user>', MASTER_PASSWORD='<repl_password>',\n")
+		fmt.Fprintf(&b, "--   MASTER_AUTO_POSITION=1;\n")
+		fmt.Fprintf(&b, "-- START SLAVE;\n")
+	}
+
+	fmt.Fprintf(&b, "--\n")
+	fmt.Fprintf(&b, "-- ── File/position alternative (gtid_mode=OFF topologies) ──\n")
+	fmt.Fprintf(&b, "-- CHANGE REPLICATION SOURCE TO\n")
+	fmt.Fprintf(&b, "--   SOURCE_HOST = '%s',\n", tm.mySQLHost.HostName)
+	fmt.Fprintf(&b, "--   SOURCE_PORT = %d,\n", tm.mySQLHost.Port)
+	fmt.Fprintf(&b, "--   SOURCE_USER = '<repl_user>',\n")
+	fmt.Fprintf(&b, "--   SOURCE_PASSWORD = '<repl_password>',\n")
+	fmt.Fprintf(&b, "--   SOURCE_LOG_FILE = '%s',\n", tm.BinlogFile)
+	fmt.Fprintf(&b, "--   SOURCE_LOG_POS = %d;\n", tm.BinlogPosition)
+	fmt.Fprintf(&b, "-- START REPLICA;\n")
+
+	if err := os.WriteFile(path, b.Bytes(), 0644); err != nil {
+		log.Fatalf("Error writing %s: %v", path, err)
+	}
+	log.Infof("Replication setup template written → %s", path)
 }
 
 func (tm *TaskManager) WriteTablesSQL(addDropTable bool) {

--- a/internal/load/gtid.go
+++ b/internal/load/gtid.go
@@ -1,0 +1,217 @@
+package load
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ChaosHour/go-dump/internal/log"
+)
+
+// gtidSetPattern matches a sanitised (whitespace-stripped) GTID set:
+// comma-separated uuid:interval[:interval...] entries. Validated before the
+// set is embedded in SQL — a GTID set never legitimately contains quotes.
+var gtidSetPattern = regexp.MustCompile(`^[0-9a-fA-F-]+(:[0-9]+(-[0-9]+)?)+(,[0-9a-fA-F-]+(:[0-9]+(-[0-9]+)?)+)*$`)
+
+// sanitizeGTIDSet strips all whitespace (metadata.json stores the set with
+// embedded newlines, as MySQL returns it) and validates the result.
+func sanitizeGTIDSet(set string) (string, error) {
+	cleaned := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\n', '\r', '\t':
+			return -1
+		}
+		return r
+	}, set)
+	if cleaned == "" {
+		return "", fmt.Errorf("GTID set is empty")
+	}
+	if !gtidSetPattern.MatchString(cleaned) {
+		return "", fmt.Errorf("GTID set %q does not look like a valid GTID set", cleaned)
+	}
+	return cleaned, nil
+}
+
+// serverVersion parses SELECT VERSION() into [major, minor, patch].
+func serverVersion(ctx context.Context, conn *sql.Conn) ([3]int, error) {
+	var raw string
+	if err := conn.QueryRowContext(ctx, "SELECT VERSION()").Scan(&raw); err != nil {
+		return [3]int{}, fmt.Errorf("detect server version: %w", err)
+	}
+	var v [3]int
+	parts := strings.Split(strings.Split(raw, "-")[0], ".")
+	for i := 0; i < 3 && i < len(parts); i++ {
+		v[i], _ = strconv.Atoi(parts[i])
+	}
+	return v, nil
+}
+
+func versionAtLeast(v [3]int, major, minor, patch int) bool {
+	if v[0] != major {
+		return v[0] > major
+	}
+	if v[1] != minor {
+		return v[1] > minor
+	}
+	return v[2] >= patch
+}
+
+// replicaConfigured reports whether the server has any replication channel,
+// and whether any channel's IO or SQL thread is running.
+func replicaConfigured(ctx context.Context, conn *sql.Conn, v [3]int) (configured, running bool, err error) {
+	stmt := "SHOW SLAVE STATUS"
+	if versionAtLeast(v, 8, 0, 22) {
+		stmt = "SHOW REPLICA STATUS"
+	}
+	rows, err := conn.QueryContext(ctx, stmt)
+	if err != nil {
+		return false, false, fmt.Errorf("%s: %w", stmt, err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return false, false, err
+	}
+	// Track the *_IO_Running / *_SQL_Running columns by position.
+	runningIdx := make([]int, 0, 2)
+	for i, c := range cols {
+		u := strings.ToUpper(c)
+		if strings.HasSuffix(u, "_IO_RUNNING") || strings.HasSuffix(u, "_SQL_RUNNING") {
+			runningIdx = append(runningIdx, i)
+		}
+	}
+
+	vals := make([]any, len(cols))
+	for i := range vals {
+		vals[i] = new(sql.RawBytes)
+	}
+	for rows.Next() {
+		configured = true
+		if err := rows.Scan(vals...); err != nil {
+			return configured, false, err
+		}
+		for _, i := range runningIdx {
+			if rb, ok := vals[i].(*sql.RawBytes); ok && strings.EqualFold(string(*rb), "Yes") {
+				running = true
+			}
+		}
+	}
+	return configured, running, rows.Err()
+}
+
+// ApplyGTIDPurged seeds the target server's GTID history from the dump's
+// captured gtid_set so the target can replicate from the dump source with
+// SOURCE_AUTO_POSITION=1.
+//
+// Safety gates, in order:
+//   - the dump GTID set must be well-formed (it is embedded in SQL);
+//   - gtid_mode must be ON on the target;
+//   - a running replication channel always aborts; a configured-but-stopped
+//     channel requires force;
+//   - if the target's gtid_executed is non-empty, it must be a subset of the
+//     dump's set (anything extra means transactions the dump source never
+//     had — errant; use go-gtids to inspect). A subset still requires force,
+//     because clearing it takes RESET MASTER / RESET BINARY LOGS AND GTIDS,
+//     which destroys the target's binlog history.
+//
+// The cheap path — empty gtid_executed, e.g. a fresh instance loaded with
+// --skip-binlog — needs no reset and no force.
+func ApplyGTIDPurged(ctx context.Context, db *sql.DB, dumpGTIDSet string, force bool) error {
+	set, err := sanitizeGTIDSet(dumpGTIDSet)
+	if err != nil {
+		return fmt.Errorf("--set-gtid-purged: %w (was the dump taken with --get-master-status?)", err)
+	}
+
+	// One connection for the whole sequence: the checks and the SET must see
+	// and act on the same session/server state.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("--set-gtid-purged: acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	var gtidMode string
+	if err := conn.QueryRowContext(ctx, "SELECT @@global.gtid_mode").Scan(&gtidMode); err != nil {
+		return fmt.Errorf("--set-gtid-purged: read gtid_mode: %w", err)
+	}
+	if !strings.EqualFold(gtidMode, "ON") {
+		return fmt.Errorf("--set-gtid-purged: target gtid_mode is %s, need ON. "+
+			"For gtid_mode=OFF topologies use file/position replication instead "+
+			"(see change-replication-source.sql in the dump directory)", gtidMode)
+	}
+
+	v, err := serverVersion(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("--set-gtid-purged: %w", err)
+	}
+
+	configured, running, err := replicaConfigured(ctx, conn, v)
+	if err != nil {
+		return fmt.Errorf("--set-gtid-purged: %w", err)
+	}
+	if running {
+		return fmt.Errorf("--set-gtid-purged: target has a RUNNING replication channel. " +
+			"Refusing to touch GTID state on an active replica — STOP REPLICA first if you really mean to re-seed it")
+	}
+	if configured && !force {
+		return fmt.Errorf("--set-gtid-purged: target has a configured (stopped) replication channel. " +
+			"Re-run with --force if you are deliberately re-seeding this replica")
+	}
+
+	var executed string
+	if err := conn.QueryRowContext(ctx, "SELECT @@global.gtid_executed").Scan(&executed); err != nil {
+		return fmt.Errorf("--set-gtid-purged: read gtid_executed: %w", err)
+	}
+	executed = strings.Join(strings.Fields(executed), "")
+
+	if executed != "" {
+		// Errant gate: anything the target executed that the dump set does not
+		// cover means writes the dump source never had. Never reset over those.
+		var extra string
+		q := fmt.Sprintf("SELECT GTID_SUBTRACT(@@global.gtid_executed, '%s')", set)
+		if err := conn.QueryRowContext(ctx, q).Scan(&extra); err != nil {
+			return fmt.Errorf("--set-gtid-purged: errant-transaction check: %w", err)
+		}
+		if strings.TrimSpace(extra) != "" {
+			return fmt.Errorf("--set-gtid-purged: target has transactions beyond the dump's GTID set: %s. "+
+				"This looks like errant transactions or a target that was never empty — inspect with "+
+				"go-gtids (https://github.com/ChaosHour/go-gtids) before touching GTID state",
+				strings.Join(strings.Fields(extra), ""))
+		}
+
+		reset := "RESET MASTER"
+		if versionAtLeast(v, 8, 4, 0) {
+			reset = "RESET BINARY LOGS AND GTIDS"
+		}
+		if !force {
+			return fmt.Errorf("--set-gtid-purged: target gtid_executed is not empty (it is a subset of the dump set, "+
+				"likely from the load itself). Clearing it requires %s, which DESTROYS the target's binlog history. "+
+				"Re-run with --force to proceed, or avoid this entirely by loading with --skip-binlog", reset)
+		}
+		log.Warningf("Executing %s on the target (destroys its binlog history).", reset)
+		if _, err := conn.ExecContext(ctx, reset); err != nil {
+			return fmt.Errorf("--set-gtid-purged: %s: %w", reset, err)
+		}
+	}
+
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET GLOBAL gtid_purged = '%s'", set)); err != nil {
+		return fmt.Errorf("--set-gtid-purged: SET GLOBAL gtid_purged: %w", err)
+	}
+
+	// Read back and confirm: gtid_executed must now equal the dump set.
+	var after string
+	if err := conn.QueryRowContext(ctx, "SELECT @@global.gtid_executed").Scan(&after); err != nil {
+		return fmt.Errorf("--set-gtid-purged: verify: %w", err)
+	}
+	if strings.Join(strings.Fields(after), "") != set {
+		return fmt.Errorf("--set-gtid-purged: verification failed: gtid_executed is %q, expected %q", after, set)
+	}
+
+	log.Infof("gtid_purged set to the dump's snapshot GTID set. Next: CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1 "+
+		"(ready-to-edit template: change-replication-source.sql in the dump directory), then START REPLICA. GTID set: %s", set)
+	return nil
+}

--- a/internal/load/gtid_test.go
+++ b/internal/load/gtid_test.go
@@ -1,0 +1,270 @@
+package load
+
+import (
+	"context"
+	"database/sql/driver"
+	"strings"
+	"testing"
+)
+
+// ── sanitizeGTIDSet ──────────────────────────────────────────────────────────
+
+func TestSanitizeGTIDSet(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"simple", "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123", "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123", false},
+		{"multi with newlines (metadata.json form)",
+			"1d1fff5a-c9bc-11ed-9c19-02a36d996b94:123,\n2ac8ec13-9255-11f0-8705-6238a95b9967:1-40586",
+			"1d1fff5a-c9bc-11ed-9c19-02a36d996b94:123,2ac8ec13-9255-11f0-8705-6238a95b9967:1-40586", false},
+		{"multiple intervals", "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5:11-18", "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5:11-18", false},
+		{"empty", "", "", true},
+		{"whitespace only", " \n\t", "", true},
+		{"sql injection attempt", "x'; DROP TABLE t; --", "", true},
+		{"quote smuggling", "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5'", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sanitizeGTIDSet(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		v       [3]int
+		m, n, p int
+		want    bool
+	}{
+		{[3]int{8, 0, 45}, 8, 4, 0, false},
+		{[3]int{8, 4, 10}, 8, 4, 0, true},
+		{[3]int{9, 7, 1}, 8, 4, 0, true},
+		{[3]int{5, 7, 44}, 8, 0, 22, false},
+		{[3]int{8, 0, 22}, 8, 0, 22, true},
+	}
+	for _, tt := range tests {
+		if got := versionAtLeast(tt.v, tt.m, tt.n, tt.p); got != tt.want {
+			t.Errorf("versionAtLeast(%v, %d.%d.%d) = %v, want %v", tt.v, tt.m, tt.n, tt.p, got, tt.want)
+		}
+	}
+}
+
+// ── ApplyGTIDPurged ──────────────────────────────────────────────────────────
+
+const dumpSet = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123"
+
+// gtidServer scripts a fake server for ApplyGTIDPurged. The zero value is a
+// fresh, empty, gtid_mode=ON MySQL 8.0 instance. Behaviours flip when the
+// corresponding SET/RESET statements execute, mimicking a real server.
+type gtidServer struct {
+	rec        *stmtRecorder
+	version    string
+	gtidMode   string
+	executed   string // current gtid_executed
+	subtract   string // GTID_SUBTRACT(executed, dumpSet) result
+	replicaRow [][]driver.Value
+	replicaCol []string
+}
+
+func newGTIDServer(rec *stmtRecorder) *gtidServer {
+	s := &gtidServer{
+		rec:        rec,
+		version:    "8.0.45",
+		gtidMode:   "ON",
+		replicaCol: []string{"Replica_IO_Running", "Replica_SQL_Running"},
+	}
+	rec.queryFn = func(q string) ([]string, [][]driver.Value, error) {
+		switch {
+		case strings.Contains(q, "gtid_mode"):
+			return []string{"@@global.gtid_mode"}, [][]driver.Value{{s.gtidMode}}, nil
+		case strings.Contains(q, "VERSION()"):
+			return []string{"VERSION()"}, [][]driver.Value{{s.version}}, nil
+		case strings.Contains(q, "REPLICA STATUS"), strings.Contains(q, "SLAVE STATUS"):
+			return s.replicaCol, s.replicaRow, nil
+		case strings.Contains(q, "GTID_SUBTRACT"):
+			return []string{"sub"}, [][]driver.Value{{s.subtract}}, nil
+		case strings.Contains(q, "gtid_executed"):
+			// Reflect state changes made by RESET / SET gtid_purged.
+			cur := s.executed
+			for _, st := range s.rec.executed() {
+				if strings.HasPrefix(st, "RESET") {
+					cur = ""
+				}
+				if strings.HasPrefix(st, "SET GLOBAL gtid_purged") {
+					cur = dumpSet
+				}
+			}
+			return []string{"@@global.gtid_executed"}, [][]driver.Value{{cur}}, nil
+		}
+		return nil, nil, nil
+	}
+	return s
+}
+
+func executedStatements(rec *stmtRecorder, prefix string) []string {
+	var out []string
+	for _, s := range rec.executed() {
+		if strings.HasPrefix(s, prefix) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func TestApplyGTIDPurged_EmptyExecutedNoResetNeeded(t *testing.T) {
+	db, rec := newFakeDB(t)
+	newGTIDServer(rec)
+
+	if err := ApplyGTIDPurged(context.Background(), db, dumpSet, false); err != nil {
+		t.Fatalf("expected success on empty gtid_executed, got: %v", err)
+	}
+	if got := executedStatements(rec, "RESET"); len(got) != 0 {
+		t.Errorf("RESET must not run when gtid_executed is empty, got: %v", got)
+	}
+	sets := executedStatements(rec, "SET GLOBAL gtid_purged")
+	if len(sets) != 1 || !strings.Contains(sets[0], dumpSet) {
+		t.Errorf("expected one SET GLOBAL gtid_purged with the dump set, got: %v", sets)
+	}
+}
+
+func TestApplyGTIDPurged_GtidModeOff(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.gtidMode = "OFF"
+
+	err := ApplyGTIDPurged(context.Background(), db, dumpSet, false)
+	if err == nil || !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected gtid_mode error, got: %v", err)
+	}
+}
+
+func TestApplyGTIDPurged_RunningReplicaRefusedEvenWithForce(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.replicaRow = [][]driver.Value{{"Yes", "Yes"}}
+
+	err := ApplyGTIDPurged(context.Background(), db, dumpSet, true)
+	if err == nil || !strings.Contains(err.Error(), "RUNNING") {
+		t.Fatalf("expected running-replica refusal, got: %v", err)
+	}
+	if got := executedStatements(rec, "SET GLOBAL gtid_purged"); len(got) != 0 {
+		t.Errorf("gtid_purged must not be touched on a running replica, got: %v", got)
+	}
+}
+
+func TestApplyGTIDPurged_StoppedChannelNeedsForce(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.replicaRow = [][]driver.Value{{"No", "No"}}
+
+	err := ApplyGTIDPurged(context.Background(), db, dumpSet, false)
+	if err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("expected force-required error for stopped channel, got: %v", err)
+	}
+
+	// Same server with --force: proceeds (gtid_executed empty → no RESET).
+	db2, rec2 := newFakeDB(t)
+	s2 := newGTIDServer(rec2)
+	s2.replicaRow = [][]driver.Value{{"No", "No"}}
+	if err := ApplyGTIDPurged(context.Background(), db2, dumpSet, true); err != nil {
+		t.Fatalf("expected success with --force on stopped channel, got: %v", err)
+	}
+}
+
+func TestApplyGTIDPurged_NonEmptySubsetNeedsForce(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.executed = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-100" // subset of dump set
+	s.subtract = ""                                           // nothing beyond the dump
+
+	err := ApplyGTIDPurged(context.Background(), db, dumpSet, false)
+	if err == nil || !strings.Contains(err.Error(), "RESET MASTER") {
+		t.Fatalf("expected error naming RESET MASTER, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--skip-binlog") {
+		t.Errorf("error should suggest --skip-binlog as the non-destructive path, got: %v", err)
+	}
+	if got := executedStatements(rec, "RESET"); len(got) != 0 {
+		t.Errorf("RESET must not run without --force, got: %v", got)
+	}
+}
+
+func TestApplyGTIDPurged_NonEmptySubsetWithForceResets(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.executed = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-100"
+	s.subtract = ""
+
+	if err := ApplyGTIDPurged(context.Background(), db, dumpSet, true); err != nil {
+		t.Fatalf("expected success with --force, got: %v", err)
+	}
+	resets := executedStatements(rec, "RESET")
+	if len(resets) != 1 || resets[0] != "RESET MASTER" {
+		t.Errorf("expected exactly [RESET MASTER] on 8.0, got: %v", resets)
+	}
+}
+
+func TestApplyGTIDPurged_84UsesResetBinaryLogs(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.version = "8.4.10"
+	s.executed = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-100"
+	s.subtract = ""
+
+	if err := ApplyGTIDPurged(context.Background(), db, dumpSet, true); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	resets := executedStatements(rec, "RESET")
+	if len(resets) != 1 || resets[0] != "RESET BINARY LOGS AND GTIDS" {
+		t.Errorf("expected [RESET BINARY LOGS AND GTIDS] on 8.4, got: %v", resets)
+	}
+}
+
+func TestApplyGTIDPurged_ErrantTransactionsAlwaysRefused(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.executed = dumpSet + ",aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:1-5"
+	s.subtract = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:1-5" // beyond the dump
+
+	err := ApplyGTIDPurged(context.Background(), db, dumpSet, true) // force must NOT override
+	if err == nil || !strings.Contains(err.Error(), "go-gtids") {
+		t.Fatalf("expected errant refusal pointing at go-gtids, got: %v", err)
+	}
+	if got := executedStatements(rec, "RESET"); len(got) != 0 {
+		t.Errorf("RESET must never run over errant transactions, got: %v", got)
+	}
+}
+
+func TestApplyGTIDPurged_InvalidSetRefused(t *testing.T) {
+	db, _ := newFakeDB(t)
+	err := ApplyGTIDPurged(context.Background(), db, "'; DROP TABLE users; --", false)
+	if err == nil || !strings.Contains(err.Error(), "valid GTID set") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+}
+
+func TestApplyGTIDPurged_57UsesShowSlaveStatus(t *testing.T) {
+	db, rec := newFakeDB(t)
+	s := newGTIDServer(rec)
+	s.version = "5.7.44"
+	s.replicaCol = []string{"Slave_IO_Running", "Slave_SQL_Running"}
+
+	if err := ApplyGTIDPurged(context.Background(), db, dumpSet, false); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if got := executedStatements(rec, "SHOW SLAVE STATUS"); len(got) != 1 {
+		t.Errorf("5.7 must use SHOW SLAVE STATUS, statements: %v", rec.executed())
+	}
+	if got := executedStatements(rec, "SHOW REPLICA STATUS"); len(got) != 0 {
+		t.Errorf("5.7 must not use SHOW REPLICA STATUS, statements: %v", rec.executed())
+	}
+}

--- a/internal/load/importer.go
+++ b/internal/load/importer.go
@@ -263,8 +263,8 @@ func execStream(ctx context.Context, conn *sql.Conn, r io.Reader) error {
 // parseStatements reads SQL from r and calls cb for each complete statement.
 // The scanner understands enough MySQL syntax that semicolons inside other
 // constructs never split a statement:
-//   - single- and double-quoted strings, with both \' and '' escaping
-//   - backtick-quoted identifiers ('' doubling, no backslash escapes)
+//   - single- and double-quoted strings, with both \' and ” escaping
+//   - backtick-quoted identifiers (” doubling, no backslash escapes)
 //   - line comments ("-- " per MySQL — the dashes must be followed by
 //     whitespace — and "#") and /* block comments */
 //
@@ -453,8 +453,10 @@ func findFiles(dir, pattern string) ([]FileLoad, error) {
 				continue
 			}
 			// master-data.sql / slave-data.sql hold replication coordinates as
-			// plain text for the operator — they are not loadable SQL.
-			if strings.HasPrefix(base, "master-data.") || strings.HasPrefix(base, "slave-data.") {
+			// plain text for the operator, and change-replication-source.sql is
+			// an operator-edited template — none are loadable during restore.
+			if strings.HasPrefix(base, "master-data.") || strings.HasPrefix(base, "slave-data.") ||
+				strings.HasPrefix(base, "change-replication-source.") {
 				continue
 			}
 			seen[p] = true

--- a/internal/load/skipbinlog_test.go
+++ b/internal/load/skipbinlog_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -26,6 +27,11 @@ type stmtRecorder struct {
 	stmts  []string
 	failOn string // statement prefix to fail
 	err    error  // error returned for failOn matches
+
+	// queryFn, when set, answers SELECT/SHOW queries: it returns column names
+	// and row values for a given query. Lets tests script server state
+	// (gtid_mode, gtid_executed, replica status) without a MySQL server.
+	queryFn func(q string) (cols []string, rows [][]driver.Value, err error)
 }
 
 func (r *stmtRecorder) record(q string) error {
@@ -64,6 +70,38 @@ func (c *fakeConn) ExecContext(_ context.Context, query string, _ []driver.Named
 		return nil, err
 	}
 	return driver.ResultNoRows, nil
+}
+
+// QueryContext answers queries via the recorder's queryFn.
+func (c *fakeConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	if err := c.rec.record(query); err != nil {
+		return nil, err
+	}
+	if c.rec.queryFn == nil {
+		return nil, fmt.Errorf("no queryFn configured for query %q", query)
+	}
+	cols, rows, err := c.rec.queryFn(query)
+	if err != nil {
+		return nil, err
+	}
+	return &fakeRows{cols: cols, rows: rows}, nil
+}
+
+type fakeRows struct {
+	cols []string
+	rows [][]driver.Value
+	i    int
+}
+
+func (r *fakeRows) Columns() []string { return r.cols }
+func (r *fakeRows) Close() error      { return nil }
+func (r *fakeRows) Next(dest []driver.Value) error {
+	if r.i >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.i])
+	r.i++
+	return nil
 }
 
 type fakeStmt struct {

--- a/test/docker-compose.versions.yml
+++ b/test/docker-compose.versions.yml
@@ -20,11 +20,14 @@
 x-mysql-env: &mysql-env
   MYSQL_ROOT_PASSWORD: s3cr3t
 
+# TCP explicitly: during first-boot init MySQL runs a temporary socket-only
+# server that answers socket pings long before the real server listens on
+# 3306 — a socket healthcheck reports healthy prematurely.
 x-healthcheck: &mysql-health
-  test: ["CMD", "mysqladmin", "ping", "-uroot", "-ps3cr3t", "--silent"]
+  test: ["CMD", "mysql", "-h127.0.0.1", "--protocol=tcp", "-uroot", "-ps3cr3t", "-e", "SELECT 1"]
   interval: 2s
   timeout: 5s
-  retries: 60
+  retries: 90
 
 services:
   mysql57:

--- a/test/test-versions.sh
+++ b/test/test-versions.sh
@@ -10,6 +10,13 @@
 #   4. asserts the row count survived the round trip
 #   5. truncates, reloads with --skip-binlog, and asserts gtid_executed is
 #      byte-identical (the load left no trace in the binlog/GTID history)
+#   6. asserts change-replication-source.sql was written with auto-position
+#      and the captured coordinates
+#   7. asserts --set-gtid-purged REFUSES while the target has transactions
+#      beyond the dump set (errant gate)
+#   8. resets the server's GTID history (version-gated RESET), reloads with
+#      --skip-binlog --set-gtid-purged, and asserts gtid_executed now equals
+#      the dump's snapshot set (go-load verifies equality internally)
 #
 # Usage: ./test/test-versions.sh [version ...]   (default: 57 80 84 9)
 
@@ -113,8 +120,43 @@ run_version() {
   [[ "$rows_after" == "$rows_before" ]] \
     || { echo "   FAIL: rows $rows_before -> $rows_after after skip-binlog reload"; return 1; }
 
+  # 4. change-replication-source.sql template written with the coordinates
+  local tmpl="$dest/change-replication-source.sql"
+  [[ -f "$tmpl" ]] || { echo "   FAIL: $tmpl not written"; return 1; }
+  grep -q "SOURCE_AUTO_POSITION = 1" "$tmpl" \
+    || { echo "   FAIL: template lacks SOURCE_AUTO_POSITION"; return 1; }
+  grep -q "SET GLOBAL gtid_purged" "$tmpl" \
+    || { echo "   FAIL: template lacks gtid_purged"; return 1; }
+
+  # 5. --set-gtid-purged must REFUSE while gtid_executed exceeds the dump set
+  #    (all the binlogged seed/drop/restore activity above is "beyond" it).
+  msql "$v" "TRUNCATE TABLE matrix.items;"
+  if $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
+      --directory "$dest" --workers 2 --data-only --set-gtid-purged --force --quiet 2>"$dest/refusal.log"; then
+    echo "   FAIL: --set-gtid-purged did not refuse a target with extra GTIDs"; return 1
+  fi
+  grep -q "beyond the dump" "$dest/refusal.log" \
+    || { echo "   FAIL: refusal did not name errant transactions:"; cat "$dest/refusal.log"; return 1; }
+
+  # 6. Reset GTID history, then the real seeding path:
+  #    --skip-binlog + --set-gtid-purged on an empty-gtid_executed server.
+  local reset="RESET MASTER"
+  case "$v" in 84|9) reset="RESET BINARY LOGS AND GTIDS" ;; esac
+  msql "$v" "$reset;"
+  msql "$v" "SET SESSION sql_log_bin=0; TRUNCATE TABLE matrix.items;"
+  $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
+    --directory "$dest" --workers 2 --data-only --skip-binlog --set-gtid-purged --quiet
+
+  local executed
+  executed=$(msql "$v" "SELECT @@global.gtid_executed;")
+  [[ -n "$executed" ]] \
+    || { echo "   FAIL: gtid_executed empty after --set-gtid-purged"; return 1; }
+  rows_after=$(msql "$v" "SELECT COUNT(*) FROM matrix.items;")
+  [[ "$rows_after" == "$rows_before" ]] \
+    || { echo "   FAIL: rows $rows_before -> $rows_after after seeding load"; return 1; }
+
   msql "$v" "DROP DATABASE matrix;"
-  echo "   PASS: dump+gtid, restore+verify, skip-binlog ($rows_before rows)"
+  echo "   PASS: dump+gtid, restore+verify, skip-binlog, template, set-gtid-purged ($rows_before rows)"
 }
 
 [[ -x $GODUMP && -x $GOLOAD ]] || { echo "Build first: make build && make build-go-load"; exit 1; }


### PR DESCRIPTION
## Summary

Closes out the two highest-value items from `docs/GTID-REPLICATION.md`: replica seeding is now one `go-load` command plus a pre-filled template, instead of hand-typed SQL.

- **`change-replication-source.sql` (dump-time)**: with `--get-master-status`, go-dump writes a ready-to-edit replica setup script with the captured coordinates filled in — active `SET GLOBAL gtid_purged` + `CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1` + `START REPLICA`, with MySQL 5.7 and file/position variants commented. Only `<repl_user>`/`<repl_password>` need editing. go-load skips it during restore; always plain text even with `--compress`.
- **`go-load --set-gtid-purged`**: after a successful load (and `--verify`), sets the target's `gtid_purged` to the dump's captured GTID set. Guard rails, in order:
  - GTID set is whitespace-stripped and format-validated before ever being embedded in SQL;
  - requires `gtid_mode=ON` (points file/position users at the template otherwise);
  - a **running** replication channel always refuses; a stopped channel requires `--force`;
  - empty `gtid_executed` (the `--skip-binlog` path): plain `SET`, no reset, no `--force`;
  - non-empty subset of the dump set: `--force` required, then version-gated `RESET MASTER` / `RESET BINARY LOGS AND GTIDS` (8.4+);
  - transactions **beyond** the dump set: refused **even with `--force`**, pointing at [go-gtids](https://github.com/ChaosHour/go-gtids) — remediation deliberately stays out of go-load;
  - post-set verification that `gtid_executed` equals the dump set exactly.
- **`--force`** flag scoped to the destructive paths above.
- README seeding recipe rewritten around the new flow; `docs/GTID-REPLICATION.md` marks items 1, 2, and the dump-time half of 3 as done (remaining: load-time `--change-source`, `.txt` rename, MariaDB flavor, `--set-gtid-purged=append`).

## Testing

- **11 new unit tests** for `ApplyGTIDPurged` against a scripted fake `database/sql` driver (query support added to the existing fake): every refusal path, RESET syntax selection by version, `SHOW SLAVE STATUS` on 5.7, SQL-injection rejection of malformed GTID sets. No MySQL required.
- **Version matrix extended** (`make test-versions`): per version now also asserts the template contents, the errant-gate *refusal* (`--set-gtid-purged --force` correctly refused while the target's GTID history exceeds the dump set), and the real seeding path (reset → `--skip-binlog --set-gtid-purged` → `gtid_executed` equals the dump's snapshot set). **PASS on 5.7.44, 8.0.45, 8.4.10, 9.7.1.**
- Fixed a matrix healthcheck race exposed by a fresh-volume run: MySQL's first-boot temporary server answers *socket* pings before the real server listens on TCP, so `compose --wait` returned early. The healthcheck now probes TCP explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)