### PR TITLE
Add --statement-size byte cap, fix go-load packet limit, replica-seeding walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ go-dump --ini-file /etc/go-dump/primary.ini --databases myapp --destination /bac
 | `--threads` | 1 | Number of parallel worker goroutines. Match to available CPU cores and disk I/O capacity. |
 | `--chunk-size` | 1000 | Rows per read chunk (key range query). Larger = fewer queries, more memory per worker. |
 | `--output-chunk-size` | 0 | Rows per `INSERT` statement. 0 = same as `--chunk-size`. |
+| `--statement-size` | 16MiB | Max **bytes** per `INSERT` statement, checked at row boundaries. Keeps wide TEXT/BLOB rows from producing statements larger than the target's `max_allowed_packet`. 0 disables. |
 | `--channel-buffer-size` | 1000 | Depth of the chunk work queue. Rarely needs tuning. |
 | `--tables-without-uniquekey` | error | What to do with tables that have no PK or unique key: `error` (abort), `single-chunk` (dump entire table in one query), `skip`. |
 
@@ -581,8 +582,12 @@ Two distinct workflows:
 
 | Goal | How |
 |------|-----|
-| Seed a new replica and start replication | Dump **with** `--get-master-status`, restore, then set `gtid_purged` and configure replication (manual SQL today — see below) |
+| Seed a new replica and start replication | Dump **with** `--get-master-status`, restore with `--skip-binlog --set-gtid-purged`, run the generated `change-replication-source.sql` |
 | Repopulate tables/databases without touching replication | Dump **without** `--get-master-status` (the default) and just restore |
+
+A complete real-world transcript of re-seeding a live replica — including the
+failures (OOM, oversized packets) and the schema-objects companion steps — is
+in [docs/REPLICA-SEEDING-WALKTHROUGH.md](docs/REPLICA-SEEDING-WALKTHROUGH.md).
 
 ### Dumping with GTIDs (replica seeding)
 

--- a/cmd/go-dump/main.go
+++ b/cmd/go-dump/main.go
@@ -49,7 +49,7 @@ func PrintUsage(flags map[string]*flag.Flag) {
 		printOption(w, flags[opt])
 	}
 	fmt.Fprintln(w, "\n# Output options:")
-	for _, opt := range []string{"destination", "add-drop-table", "get-master-status", "get-slave-status", "output-chunk-size", "skip-use-database"} {
+	for _, opt := range []string{"destination", "add-drop-table", "get-master-status", "get-slave-status", "output-chunk-size", "statement-size", "skip-use-database"} {
 		printOption(w, flags[opt])
 	}
 	w.Flush()
@@ -77,6 +77,7 @@ func main() {
 	flag.IntVar(&dumpOptions.Threads, "threads", 1, "Number of threads to use.")
 	flag.Uint64Var(&dumpOptions.ChunkSize, "chunk-size", 1000, "Number of rows per read chunk.")
 	flag.Uint64Var(&dumpOptions.OutputChunkSize, "output-chunk-size", 0, "Number of rows per INSERT statement (0 = same as --chunk-size).")
+	flag.Uint64Var(&dumpOptions.StatementSize, "statement-size", 16*1024*1024, "Max bytes per INSERT statement. Rows are grouped until this cap so wide TEXT/BLOB rows never exceed the target's max_allowed_packet. 0 disables the cap.")
 	flag.IntVar(&dumpOptions.ChannelBufferSize, "channel-buffer-size", 1000, "Task channel buffer size.")
 	flag.BoolVar(&dumpOptions.LockTables, "lock-tables", true, "Lock tables to get a consistent backup.")
 	flag.StringVar(&dumpOptions.TablesWithoutUKOption, "tables-without-uniquekey", "error", "Action for tables without a primary or unique key. Valid: 'error', 'single-chunk', 'skip'.")

--- a/cmd/go-load/main.go
+++ b/cmd/go-load/main.go
@@ -194,6 +194,10 @@ func connect(host string, port int, user, password, socket, database string) (*s
 	cfg.DBName = database
 	cfg.AllowNativePasswords = true
 	cfg.ParseTime = true
+	// 0 = ask the server for max_allowed_packet. Without this the driver
+	// refuses statements over its own default even when the server would
+	// accept them ("packet for query is too large").
+	cfg.MaxAllowedPacket = 0
 
 	if socket != "" {
 		cfg.Net = "unix"

--- a/docs/REPLICA-SEEDING-WALKTHROUGH.md
+++ b/docs/REPLICA-SEEDING-WALKTHROUGH.md
@@ -1,0 +1,249 @@
+# Walkthrough: re-seeding a live replica with go-dump / go-load (GTID auto-position)
+
+A real, start-to-finish transcript of wiping a replica and re-seeding it from
+its primary using GTIDs — run 2026-07-03 against a MySQL 8.0.43 Docker pair
+(`primary1` on 3306 → `replica1` on 3307, GTID replication, channel
+`source_3`, `Auto_Position=1`). Every output below is from the actual run,
+including the two failures and what they taught us.
+
+The same flow seeds a **brand-new** replica; the differences are called out in
+[Fresh replica vs re-seed](#fresh-replica-vs-re-seed).
+
+## The flags that make this work
+
+| Flag | Tool | What it does |
+|------|------|--------------|
+| `--get-master-status` | go-dump | Captures binlog file/position + `Executed_Gtid_Set` **inside the lock window**, writes them to `metadata.json` and `master-data.sql`, and generates `change-replication-source.sql` |
+| `--checksum` | go-dump | `CHECKSUM TABLE` per table → `checksums.txt`, verified later by `go-load --verify` |
+| `--statement-size` | go-dump | Caps INSERT statement bytes (default 16MiB) so wide TEXT/BLOB rows can't exceed the target's `max_allowed_packet` |
+| `--skip-binlog` | go-load | `SET SQL_LOG_BIN=0` on every load connection — the restore adds nothing to the replica's own GTID history |
+| `--set-gtid-purged` | go-load | After the load, sets `gtid_purged` to the dump's snapshot GTID set, with safety gates (see step 5) |
+| `--force` | go-load | Required here because the target has a configured (stopped) channel and a non-empty `gtid_executed` |
+
+## Step 0 — Recon: know what you're about to destroy
+
+```bash
+mysql --defaults-group-suffix=_replica1 --commands=on -e "SHOW REPLICA STATUS\G" \
+  | grep -E "Source_Host|Source_User|Auto_Position|Channel_Name|Running:"
+```
+```
+                  Source_Host: 172.20.0.3
+                  Source_User: repl
+           Replica_IO_Running: Yes
+          Replica_SQL_Running: Yes
+                Auto_Position: 1
+                 Channel_Name: source_3
+```
+
+Three things this told us:
+
+- **Auto_Position=1 and a named channel** — the replica's connection config
+  (including the stored `repl` password) lives in `mysql.slave_master_info`
+  and **survives** `STOP REPLICA` and `RESET MASTER`. We will not need the
+  replication password at all. (`RESET REPLICA ALL` would wipe it — don't.)
+- **Databases to reseed**: `ca_analysis chaos go_bills roll_back sakila`.
+- **Objects go-dump won't carry**: 9 views, 7 routines, 6 triggers, 1 event
+  (`information_schema.views/routines/triggers/events`). Step 6 handles them.
+
+## Step 1 — Dump the primary with GTID capture
+
+```bash
+go-dump --mysql-host 127.0.0.1 --mysql-port 3306 --mysql-user root --mysql-password ... \
+  --all-databases --destination ./test-seed \
+  --tables-without-uniquekey single-chunk \
+  --threads 4 --chunk-size 50000 --output-chunk-size 5000 \
+  --get-master-status --checksum --add-drop-table \
+  --execute
+```
+```
+INFO Locking tables to synchronise worker snapshots and binlog position.
+INFO Replication setup template written → test-seed/change-replication-source.sql
+INFO Unlocking the tables. Tables were locked for 20.459492ms
+INFO Checksums written for 25 tables → ./test-seed/checksums.txt
+INFO Dump complete.
+```
+
+The primary was **locked for ~20ms** — that's the entire production impact of
+capturing coordinates that exactly match the data. `metadata.json` now holds:
+
+```json
+"binlog_file": "binlog.000056",
+"gtid_set": "1d1fff5a-...:123,\n2ac8ec13-...:1-40595,\n2af7e535-...:1-11"
+```
+
+### What went wrong first (kept here on purpose)
+
+Our first two attempts failed, and both failures are things you'll hit in real
+production:
+
+1. **Replica OOM-killed (exit 137).** The first dump used the default
+   `--output-chunk-size` (= `--chunk-size` = 50,000 rows per INSERT). Four
+   load workers × ~50k-row statements against a memory-constrained Docker VM
+   killed mysqld mid-load. Fix: `--output-chunk-size 5000` and fewer load
+   workers. Match statement size and parallelism to the *target's* memory,
+   not the source's.
+2. **`packet for query is too large`.** One table (`chaos.notes`, huge TEXT
+   rows) produced a **single 148MB INSERT statement** — row-count grouping
+   says nothing about bytes. This drove two fixes now in the code:
+   go-dump's `--statement-size` (default 16MiB byte cap per INSERT — the same
+   148MB of data now dumps as 7 statements) and go-load negotiating
+   `max_allowed_packet` with the server instead of refusing at the driver
+   default.
+
+## Step 2 — Stop replication on the replica
+
+```sql
+STOP REPLICA;   -- config and credentials remain stored
+```
+
+`--set-gtid-purged` refuses to run against a **running** channel no matter
+what, so this is not optional.
+
+## Step 3 — Drop the user databases on the replica
+
+```sql
+SET SESSION sql_log_bin=0;
+DROP DATABASE ca_analysis; DROP DATABASE chaos; DROP DATABASE go_bills;
+DROP DATABASE roll_back;  DROP DATABASE sakila;
+```
+
+`sql_log_bin=0` matters: without it every DROP generates a GTID under the
+*replica's* server_uuid — errant transactions you'd have to explain away
+later. System schemas (`mysql`, `sys`) are untouched, so users/grants survive.
+
+## Step 4 — Load + GTID handoff in one command
+
+```bash
+go-load --host 127.0.0.1 --port 3307 --user root --password ... \
+  --directory ./test-seed --workers 2 --verify \
+  --skip-binlog --set-gtid-purged --force
+```
+
+What each part did in this run:
+
+- `--skip-binlog` — the restore wrote nothing to the replica's binlog or GTID
+  history.
+- `--verify` — re-ran `CHECKSUM TABLE` on the replica and compared with
+  `checksums.txt` from the dump.
+- `--set-gtid-purged` walked its gates: GTID set validated → `gtid_mode=ON` →
+  channel exists but stopped (allowed by `--force`) → `gtid_executed`
+  non-empty but a **subset** of the dump set → `--force` authorizes
+  `RESET MASTER` → `SET GLOBAL gtid_purged = '<dump set>'` → read-back
+  verified equal.
+
+Why `--force` was genuinely needed twice over: the replica had a configured
+channel, and its `gtid_executed` still held the old history (`RESET MASTER`
+is destructive, so it is never implicit). On a **fresh** instance neither
+condition exists and `--force` is unnecessary.
+
+Had the replica contained transactions **beyond** the dump set (true errant
+transactions), `--set-gtid-purged` would have refused **even with `--force`**
+and pointed at [go-gtids](https://github.com/ChaosHour/go-gtids).
+
+Actual output of step 4 in this run:
+
+```
+INFO Progress: 25/25 files loaded
+INFO All checksums verified OK (./test-seed/checksums.txt)
+INFO Applying the dump's GTID set to the target (--set-gtid-purged)...
+WARNING Executing RESET MASTER on the target (destroys its binlog history).
+INFO gtid_purged set to the dump's snapshot GTID set. Next: CHANGE REPLICATION
+     SOURCE TO ... SOURCE_AUTO_POSITION=1 ..., then START REPLICA.
+```
+
+## Step 5 — Views, routines, triggers, events
+
+go-dump moves base tables only. This schema had 9 views, 7 routines,
+6 triggers, 1 event — without them the replica errors on any read through a
+view, even though replication itself would run fine. Copy them with
+mysqldump, **loading with binlog disabled** for the same errant-GTID reason
+as step 3.
+
+Two mysqldump traps we hit doing this for real:
+
+- **`--set-gtid-purged=OFF` is mandatory.** mysqldump's default (`AUTO`)
+  embeds `SET @@GLOBAL.GTID_PURGED` in its output when `gtid_mode=ON` — which
+  fails (or worse) on a replica whose GTID state you just set. This is the
+  exact footgun go-dump's own files avoid by design.
+- **`--no-create-info` suppresses view definitions too**, not just
+  `CREATE TABLE`. Routines/triggers/events came through; views silently
+  didn't. Views need their own pass, named explicitly per database.
+
+```bash
+# Routines, triggers, events (no table DDL, no data):
+mysqldump -h primary -uroot -p --no-data --no-create-info \
+  --routines --events --triggers --set-gtid-purged=OFF \
+  --databases ca_analysis chaos go_bills roll_back sakila \
+  | mysql -h replica -uroot -p --init-command="SET SESSION sql_log_bin=0"
+
+# Views: name them explicitly (per database), write to a file, then load.
+# (In zsh, use ${=views} — zsh does not word-split unquoted variables.)
+for db in chaos sakila; do
+  views=$(mysql -h primary -N -e \
+    "SELECT table_name FROM information_schema.views WHERE table_schema='$db';" | tr '\n' ' ')
+  echo "USE \`$db\`;" >> views.sql
+  mysqldump -h primary -uroot -p --no-data --skip-triggers --set-gtid-purged=OFF \
+    $db $views >> views.sql
+done
+mysql -h replica -uroot -p --init-command="SET SESSION sql_log_bin=0" < views.sql
+```
+
+Result in this run: `views: 9, routines: 7, triggers: 6, events: 1` on the
+replica, and `gtid_executed` unchanged throughout (the `--init-command`
+binlog-off trick verified after every load).
+
+## Step 6 — Start replication
+
+The channel config survived, so for a re-seed it's just:
+
+```sql
+START REPLICA;
+```
+```
+Replica_IO_Running: Yes
+Replica_SQL_Running: Yes
+Seconds_Behind_Source: 0
+Auto_Position: 1
+```
+
+With `Auto_Position=1`, the replica tells the primary "I have exactly the
+dump's GTID set" and the primary streams everything after the snapshot.
+
+## Step 7 — Prove it
+
+```bash
+# 1. Marker row written on the PRIMARY:
+#    CREATE TABLE chaos.seed_check (...); INSERT ... 'replicated after seed';
+#    → appeared on the replica within seconds.
+
+# 2. Errant-transaction check:
+go-gtids -s 127.0.0.1 -source-port 3306 -t 127.0.0.1 -target-port 3307
+# [+] No Errant Transactions:
+
+# 3. Row-count spot checks, primary vs replica:
+#    sakila.rental:                     16044 = 16044  OK
+#    sakila.payment:                    16049 = 16049  OK
+#    ca_analysis.DailyBudgetDetail_test: 8496868 = 8496868  OK
+#    chaos.notes (the 148MB-of-TEXT table): 903 = 903  OK
+```
+
+## Fresh replica vs re-seed
+
+| | Re-seed (this run) | Fresh replica |
+|---|---|---|
+| `STOP REPLICA` first | Required | n/a |
+| `--force` | Required (stopped channel + non-empty `gtid_executed`) | Not needed |
+| `RESET MASTER` | Run by `--set-gtid-purged` under `--force` | Not needed (`gtid_executed` empty with `--skip-binlog`) |
+| `CHANGE REPLICATION SOURCE TO` | Skipped — stored config survives | Edit `<repl_user>`/`<repl_password>` in the dump's `change-replication-source.sql` and run it |
+
+## Operator checklist
+
+- [ ] `SHOW REPLICA STATUS` — note channel name, Auto_Position, source host
+- [ ] Count views/routines/triggers/events — plan the mysqldump companion step
+- [ ] Dump with `--get-master-status --checksum`; sane `--output-chunk-size`
+- [ ] `STOP REPLICA`
+- [ ] Drop user databases with `sql_log_bin=0`
+- [ ] `go-load --verify --skip-binlog --set-gtid-purged` (`--force` for re-seeds)
+- [ ] Load schema objects with `sql_log_bin=0`
+- [ ] `START REPLICA` (or run the edited `change-replication-source.sql`)
+- [ ] Marker-row test + go-gtids clean

--- a/internal/dump/datachunk.go
+++ b/internal/dump/datachunk.go
@@ -67,10 +67,29 @@ func (dc *DataChunk) GetSampleSQL() string {
 	return fmt.Sprintf("SELECT * FROM %s LIMIT 1", dc.Task.Table.GetFullName())
 }
 
+// countingWriter tracks bytes written so Parse can cap INSERT statement size.
+type countingWriter struct {
+	w io.Writer
+	n uint64
+}
+
+func (cw *countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.n += uint64(n)
+	return n, err
+}
+
 // Parse executes the chunk query and writes the resulting INSERT statements to w.
 // Callers stage the output in memory so a failed chunk can be retried without
 // duplicating rows already written to the dump file.
-func (dc *DataChunk) Parse(stmt *sql.Stmt, buffer io.Writer) error {
+//
+// Rows are grouped into multi-row INSERTs, split on whichever limit is hit
+// first: OutputChunkSize rows, or StatementSize bytes. The byte cap exists
+// because wide rows (large TEXT/BLOB columns) can push a row-count-only group
+// past the target server's max_allowed_packet, producing a dump that cannot
+// be restored anywhere. The cap is checked at row boundaries, so a statement
+// can exceed it by at most one row.
+func (dc *DataChunk) Parse(stmt *sql.Stmt, w io.Writer) error {
 	var rows *sql.Rows
 	var err error
 	if dc.IsSingleChunk {
@@ -87,6 +106,9 @@ func (dc *DataChunk) Parse(stmt *sql.Stmt, buffer io.Writer) error {
 		return fmt.Errorf("query chunk for %s: %w", dc.Task.Table.GetFullName(), err)
 	}
 	defer rows.Close()
+
+	buffer := &countingWriter{w: w}
+	maxStmtBytes := dc.Task.TaskManager.DumpOptions.StatementSize
 
 	tablename := dc.Task.Table.GetFullName()
 	if dc.IsSingleChunk {
@@ -112,6 +134,7 @@ func (dc *DataChunk) Parse(stmt *sql.Stmt, buffer io.Writer) error {
 
 	firstRow := true
 	var rowsNumber uint64
+	var stmtStart uint64 // buffer.n at the start of the current INSERT statement
 
 	for rows.Next() {
 		err = rows.Scan(buff...)
@@ -120,12 +143,17 @@ func (dc *DataChunk) Parse(stmt *sql.Stmt, buffer io.Writer) error {
 		}
 
 		if firstRow {
+			stmtStart = buffer.n
 			fmt.Fprintf(buffer, insertPrefix)
 			firstRow = false
 		} else {
 			rowsNumber++
-			if dc.Task.OutputChunkSize > 0 && rowsNumber%dc.Task.OutputChunkSize == 0 {
-				fmt.Fprintf(buffer, ");\n%s", insertPrefix)
+			splitOnRows := dc.Task.OutputChunkSize > 0 && rowsNumber%dc.Task.OutputChunkSize == 0
+			splitOnBytes := maxStmtBytes > 0 && buffer.n-stmtStart >= maxStmtBytes
+			if splitOnRows || splitOnBytes {
+				fmt.Fprintf(buffer, ");\n")
+				stmtStart = buffer.n
+				fmt.Fprintf(buffer, insertPrefix)
 			} else {
 				fmt.Fprintf(buffer, "),\n(")
 			}

--- a/internal/dump/options.go
+++ b/internal/dump/options.go
@@ -9,6 +9,7 @@ type DumpOptions struct {
 	Threads               int
 	ChunkSize             uint64
 	OutputChunkSize       uint64
+	StatementSize         uint64 // max bytes per INSERT statement; a row group is flushed once it exceeds this
 	ChannelBufferSize     int
 	LockTables            bool
 	TablesWithoutUKOption string
@@ -53,6 +54,7 @@ func GetDumpOptions() *DumpOptions {
 		Threads:               1,
 		ChunkSize:             1000,
 		OutputChunkSize:       0,
+		StatementSize:         16 * 1024 * 1024,
 		ChannelBufferSize:     1000,
 		LockTables:            true,
 		TablesWithoutUKOption: "error",


### PR DESCRIPTION
## Summary

Both code changes came out of re-seeding a **live replica** end-to-end with the PR #8 features — the full transcript (failures included) is the new walkthrough doc.

- **go-dump `--statement-size`** (new flag, default 16MiB): INSERT row groups now split on **bytes** as well as `--output-chunk-size` rows, checked at row boundaries (a statement can exceed the cap by at most one row). Previously a table with huge TEXT rows (`chaos.notes`, 903 rows) produced a **single 148MB INSERT statement** that no default server (`max_allowed_packet=64MB`) could load; the same table now dumps as 7 loadable statements.
- **go-load packet negotiation**: `Config.MaxAllowedPacket = 0` so the driver asks the server for `max_allowed_packet` instead of refusing large statements at its own client-side default (`packet for query is too large`).
- **`docs/REPLICA-SEEDING-WALKTHROUGH.md`**: real, unedited transcript of wiping and re-seeding a live MySQL 8.0.43 replica using `go-load --skip-binlog --set-gtid-purged --force`, kept honest with both failures (target mysqld OOM-killed by oversized statements × parallel workers; the 148MB packet error) and their fixes. Also covers the schema-objects companion steps with two mysqldump traps hit live: `--set-gtid-purged=OFF` is mandatory when `gtid_mode=ON`, and `--no-create-info` silently suppresses **views** (routines/triggers/events came through; views need an explicitly-named pass). Ends with a fresh-replica vs re-seed comparison and an operator checklist.
- README: `--statement-size` in the flags table; walkthrough linked from "Replication and GTIDs".

## Testing

- Unit suites pass (dump + load).
- Live validation: replica re-seeded from a 5-database dump (25 tables, ~8.5M-row largest); after `START REPLICA` — IO/SQL threads running, 0s behind, marker row replicated, `go-gtids` reports no errant transactions, row-count spot checks equal on all checked tables including the previously-unloadable 148MB TEXT table.
- The `--set-gtid-purged --force` path was exercised for real: configured (stopped) channel + non-empty subset `gtid_executed` → `RESET MASTER` → set → read-back verified; stored channel credentials survived, so replication restarted without the repl password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)