### PR TITLE
Scale hardening: stream single-chunk tables, bound lock waits, scale test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,20 @@ go-dump --ini-file /etc/go-dump/primary.ini --databases myapp --destination /bac
 | `--output-chunk-size` | 0 | Rows per `INSERT` statement. 0 = same as `--chunk-size`. |
 | `--statement-size` | 16MiB | Max **bytes** per `INSERT` statement, checked at row boundaries. Keeps wide TEXT/BLOB rows from producing statements larger than the target's `max_allowed_packet`. 0 disables. |
 | `--channel-buffer-size` | 1000 | Depth of the chunk work queue. Rarely needs tuning. |
-| `--tables-without-uniquekey` | error | What to do with tables that have no PK or unique key: `error` (abort), `single-chunk` (dump entire table in one query), `skip`. |
+| `--tables-without-uniquekey` | error | What to do with tables that have no usable chunk key: `error` (abort), `single-chunk` (dump entire table in one query, streamed), `skip`. Chunking needs a **single-column integer NOT NULL** primary/unique key — UUID/VARCHAR and composite keys fall into this option too. |
+
+### Memory and large tables
+
+- Worker memory ≈ `--threads` × (`--chunk-size` rows × average row bytes): each
+  chunk is staged in memory before it is written, so wide rows want a smaller
+  `--chunk-size`. Single-chunk tables are **streamed** and do not stage.
+- `--statement-size` (16MiB default) bounds INSERT statement bytes so the dump
+  stays loadable regardless of row width; raise `--output-chunk-size` /
+  `--chunk-size` for throughput, not beyond the target's memory.
+- On the **load** side, memory ≈ `--workers` × largest single statement; the
+  target server must also parse each statement — during a live re-seed test, 4
+  workers × 50k-row INSERTs OOM-killed a small MySQL container. Start with
+  `--workers 2` and 5000-row statements when the target is memory-constrained.
 
 ### Consistency
 
@@ -199,6 +212,7 @@ go-dump --ini-file /etc/go-dump/primary.ini --databases myapp --destination /bac
 |------|---------|-------------|
 | `--consistent` | true | Require a consistent (point-in-time) backup via MVCC. |
 | `--lock-tables` | true | Lock tables to establish the consistent snapshot. Required when `--consistent=true`. |
+| `--lock-wait-timeout` | 60 | Seconds to wait for `FLUSH TABLES WITH READ LOCK` / `LOCK TABLES` before aborting. Without a bound, a lock queued behind one long-running query stalls every subsequent query on the server. 0 = server default. |
 | `--isolation-level` | REPEATABLE READ | Transaction isolation level. Options: `REPEATABLE READ`, `READ COMMITTED`, `READ UNCOMMITTED`, `SERIALIZABLE`. |
 
 ### Output

--- a/cmd/go-dump/main.go
+++ b/cmd/go-dump/main.go
@@ -36,7 +36,7 @@ func PrintUsage(flags map[string]*flag.Flag) {
 
 	fmt.Fprintln(w, "# General:")
 	for _, opt := range []string{"help", "dry-run", "execute", "debug", "quiet", "version",
-		"lock-tables", "channel-buffer-size", "chunk-size", "tables-without-uniquekey",
+		"lock-tables", "lock-wait-timeout", "channel-buffer-size", "chunk-size", "tables-without-uniquekey",
 		"threads", "compress", "compress-level", "consistent", "isolation-level", "where", "ini-file"} {
 		printOption(w, flags[opt])
 	}
@@ -80,6 +80,7 @@ func main() {
 	flag.Uint64Var(&dumpOptions.StatementSize, "statement-size", 16*1024*1024, "Max bytes per INSERT statement. Rows are grouped until this cap so wide TEXT/BLOB rows never exceed the target's max_allowed_packet. 0 disables the cap.")
 	flag.IntVar(&dumpOptions.ChannelBufferSize, "channel-buffer-size", 1000, "Task channel buffer size.")
 	flag.BoolVar(&dumpOptions.LockTables, "lock-tables", true, "Lock tables to get a consistent backup.")
+	flag.IntVar(&dumpOptions.LockWaitTimeout, "lock-wait-timeout", 60, "Seconds to wait for FLUSH TABLES WITH READ LOCK / LOCK TABLES before aborting. Prevents a blocked lock from stalling the whole server. 0 = server default.")
 	flag.StringVar(&dumpOptions.TablesWithoutUKOption, "tables-without-uniquekey", "error", "Action for tables without a primary or unique key. Valid: 'error', 'single-chunk', 'skip'.")
 	flag.BoolVar(&dumpOptions.TemporalOptions.Debug, "debug", false, "Display debug information.")
 	flag.StringVar(&dumpOptions.DestinationDir, "destination", "", "Directory to store the dumps.")

--- a/docs/SCALE-TEST-PLAN.md
+++ b/docs/SCALE-TEST-PLAN.md
@@ -1,0 +1,75 @@
+# Scale test plan — what must pass before calling go-dump production-ready at size
+
+Everything validated so far ran against small Docker databases (largest table:
+8.5M rows / ~1GB; largest single value: ~MB-scale TEXT). This plan lists the
+tests that close the gap to "trusted on real production sizes", roughly in
+order of risk.
+
+## Known scale-sensitive design points (verify, don't assume)
+
+| Area | Design today | Risk at size |
+|------|--------------|--------------|
+| Chunk staging | Each keyed chunk staged in RAM before write (retry safety) | `threads × chunk bytes` of RAM; wide rows × big `--chunk-size` can OOM the dump host |
+| Single-chunk tables | Streamed (not staged) since the scale-hardening branch; one unchunked query, no parallelism | A 500GB keyless table = one thread, one multi-hour query, one huge file; long-running snapshot |
+| Chunk boundary discovery | One `LIMIT 1 OFFSET chunk-size` index probe per chunk, serial per table | ~20k probes for a 1B-row table at 50k chunk — measure, it may dominate |
+| Snapshot lifetime | Workers hold REPEATABLE READ snapshots for the whole dump | Hours-long snapshots on a busy primary → InnoDB history-list growth, undo bloat, purge lag |
+| Lock acquisition | `--lock-wait-timeout` (60s default) bounds FTWRL wait | Verify behaviour when FTWRL queues behind a long query: dump aborts cleanly, server unblocks |
+| ETA / progress | Row estimates from `information_schema.TABLE_ROWS` | Estimates can be off ±50% on big InnoDB tables; cosmetic |
+| Checksums | `CHECKSUM TABLE` after unlock, full table scan | Hours on TB tables; drift on a live primary makes them advisory |
+| Resume | Per-table granularity; mixed-snapshot warning | Resumed dumps are NOT one snapshot — never use a resumed dump + its GTID set for seeding |
+
+## Tier 1 — must pass (correctness and survival)
+
+1. **100GB+ single database, mixed schema** (int PKs, UUID PK, composite PK,
+   one keyless table ≥ 5GB, one table with TEXT/BLOB rows ≥ 10MB each):
+   - dump completes; RSS of go-dump stays ≈ `threads × chunk bytes` (monitor
+     with `ps`/`time -v`); no statement in output exceeds `--statement-size`
+     by more than one row.
+   - full restore onto a default-config target (64MB `max_allowed_packet`,
+     no server tuning) succeeds; `go-load --verify` passes.
+2. **Sparse/skewed keys**: table with AUTO_INCREMENT gaps (e.g. delete 90% of
+   rows) — chunk count and runtime stay sane (OFFSET probing is by row count,
+   not key value, so gaps should not matter — verify).
+3. **Negative and near-BIGINT-max keys**: signed key starting below zero and
+   unsigned key above 2^63 — the first must dump completely; the second must
+   fail loudly (documented), not silently truncate.
+4. **Kill/resume at size**: kill -9 the dump at ~50%; `--resume` finishes;
+   restore + `CHECKSUM TABLE` against source matches (quiesced source).
+5. **Replica seeding at size**: full walkthrough (docs/REPLICA-SEEDING-
+   WALKTHROUGH.md) against ≥100GB with concurrent writes on the primary
+   during the dump; after `START REPLICA`, replica catches up and
+   `pt-table-checksum` (or quiesced `CHECKSUM TABLE`) matches; go-gtids clean.
+
+## Tier 2 — should pass (production behaviour)
+
+6. **Busy-primary lock test**: run a deliberate 5-minute `SELECT SLEEP()`-ish
+   query, start the dump — FTWRL must abort at `--lock-wait-timeout` with the
+   processlist hint, and the server must be unblocked immediately after.
+7. **Long-snapshot impact**: dump a 4+ hour dataset on a primary taking
+   steady writes; graph history list length — document the impact and the
+   "dump from a replica" recommendation.
+8. **Network blips**: drop the dump connection mid-run (kill it server-side)
+   — dump must abort (snapshot lost, not retryable) with a clear error, and
+   `--resume` must recover.
+9. **Disk-full on destination** mid-dump: hard abort, no `complete` status in
+   metadata.json.
+10. **go-load into a 5.7→8.0 upgrade target** at size (charset/collation
+    edge: `utf8mb3` sources).
+
+## Tier 3 — nice to have
+
+11. Compressed dump at size (`--compress`) — CPU vs size tradeoff numbers for
+    the README.
+12. Throughput tuning table: threads × chunk-size matrix on the test box,
+    published in the README.
+13. `--dry-run` cost on a 1B-row table (it runs the full chunk probing).
+
+## Suggested rig
+
+- Generate data with `sysbench oltp_common` (int PKs) plus custom tables for
+  UUID/keyless/wide-TEXT shapes, or restore a production-shaped snapshot into
+  a lab instance.
+- Two VMs (or two large containers with fixed `--memory` limits to make OOM
+  behaviour deterministic and observable), MySQL 8.0, `gtid_mode=ON`.
+- Record for every run: wall time, go-dump RSS peak, mysqld RSS on both ends,
+  history list length peak, dump size on disk, restore wall time.

--- a/internal/dump/options.go
+++ b/internal/dump/options.go
@@ -12,6 +12,7 @@ type DumpOptions struct {
 	StatementSize         uint64 // max bytes per INSERT statement; a row group is flushed once it exceeds this
 	ChannelBufferSize     int
 	LockTables            bool
+	LockWaitTimeout       int // seconds to wait for FTWRL / LOCK TABLES before aborting
 	TablesWithoutUKOption string
 	DestinationDir        string
 	AddDropTable          bool
@@ -30,9 +31,9 @@ type DumpOptions struct {
 }
 
 type TemporalOptions struct {
-	Tables, Databases, IsolationLevel                    string
-	AllDatabases, Debug, DryRun, Execute, Quiet          bool
-	IncludeSystemDatabases                               bool
+	Tables, Databases, IsolationLevel           string
+	AllDatabases, Debug, DryRun, Execute, Quiet bool
+	IncludeSystemDatabases                      bool
 }
 
 type MySQLHost struct {
@@ -57,6 +58,7 @@ func GetDumpOptions() *DumpOptions {
 		StatementSize:         16 * 1024 * 1024,
 		ChannelBufferSize:     1000,
 		LockTables:            true,
+		LockWaitTimeout:       60,
 		TablesWithoutUKOption: "error",
 		AddDropTable:          false,
 		GetMasterStatus:       true,

--- a/internal/dump/task.go
+++ b/internal/dump/task.go
@@ -113,6 +113,14 @@ func (t *Task) CreateChunks(db *sql.DB) {
 		switch t.TaskManager.TablesWithoutPKOption {
 		case "single-chunk":
 			log.Debugf("Table %s has no primary/unique key — dumping as a single chunk.", t.Table.GetFullName())
+			// A single-chunk table is read in one unchunked query with no
+			// parallelism. Warn when it is large so slow dumps are explained
+			// up front (estimate from information_schema, so approximate).
+			if t.Table.estDataSize > 1<<30 {
+				log.Warningf("Table %s (~%.1f GB) has no single-column integer key and will dump as ONE unchunked query — "+
+					"no parallelism for this table. Consider adding an integer key.",
+					t.Table.GetFullName(), float64(t.Table.estDataSize)/(1<<30))
+			}
 			err := tx.QueryRowContext(ctx, t.GetSingleChunkTestQuery()).Scan(&chunkMax)
 			switch {
 			case err == nil:

--- a/internal/dump/taskmanager.go
+++ b/internal/dump/taskmanager.go
@@ -603,9 +603,27 @@ func (tm *TaskManager) GetTransactions(lockTables bool, allDatabases bool) {
 			// non-InnoDB engines during the window.
 			lockSQL = GetLockAllTablesSQL()
 		}
+
+		// MySQL's default lock_wait_timeout is one year. FTWRL queues behind
+		// any long-running statement, and every query issued after it queues
+		// behind FTWRL — so an unbounded wait turns one slow query into a
+		// server-wide stall. Bound it and fail loudly instead.
+		timeout := tm.DumpOptions.LockWaitTimeout
+		if timeout > 0 {
+			if _, err := lockConn.ExecContext(tm.ctx,
+				fmt.Sprintf("SET SESSION lock_wait_timeout = %d", timeout)); err != nil {
+				log.Warningf("Could not set lock_wait_timeout: %v", err)
+			}
+		}
+
 		log.Info("Locking tables to synchronise worker snapshots and binlog position.")
 		startLocking = time.Now()
 		if _, err := lockConn.ExecContext(tm.ctx, lockSQL); err != nil {
+			var me *mysql.MySQLError
+			if errors.As(err, &me) && me.Number == 1205 {
+				log.Fatalf("Could not acquire the table lock within %ds — a long-running query is likely blocking it. "+
+					"Check SHOW PROCESSLIST, retry when quiet, or raise --lock-wait-timeout. Error: %v", timeout, err)
+			}
 			log.Fatalf("Error locking the tables: %v", err)
 		}
 	}
@@ -793,26 +811,37 @@ func (tm *TaskManager) StartWorker(workerId int) {
 			log.Fatalf("Error writing dump file for %s: %v", tablename, err)
 		}
 
-		var parseErr error
-		for attempt := 1; ; attempt++ {
-			chunkStage.Reset()
-			parseErr = chunk.Parse(stmt, &chunkStage)
-			if parseErr == nil || attempt >= maxChunkAttempts || !isRetryableChunkError(parseErr) {
-				break
+		if chunk.IsSingleChunk {
+			// Whole-table chunks (no usable integer key) are streamed straight
+			// to the dump file: staging them would hold the entire table in
+			// memory, which OOMs the dump host on large keyless tables. The
+			// trade-off is no transparent retry — bytes may already be on
+			// disk, so any error must abort the dump.
+			if err := chunk.Parse(stmt, buffer); err != nil {
+				log.Fatalf("Error dumping single-chunk table %s: %s", chunk.Task.Table.GetFullName(), err.Error())
 			}
-			log.Warningf("Transient error on chunk %d of %s (attempt %d/%d), retrying: %v",
-				chunk.Sequence, tablename, attempt, maxChunkAttempts, parseErr)
-			select {
-			case <-tm.ctx.Done():
-				log.Fatalf("Dump cancelled while retrying chunk for %s: %v", tablename, tm.ctx.Err())
-			case <-time.After(time.Duration(attempt) * time.Second):
+		} else {
+			var parseErr error
+			for attempt := 1; ; attempt++ {
+				chunkStage.Reset()
+				parseErr = chunk.Parse(stmt, &chunkStage)
+				if parseErr == nil || attempt >= maxChunkAttempts || !isRetryableChunkError(parseErr) {
+					break
+				}
+				log.Warningf("Transient error on chunk %d of %s (attempt %d/%d), retrying: %v",
+					chunk.Sequence, tablename, attempt, maxChunkAttempts, parseErr)
+				select {
+				case <-tm.ctx.Done():
+					log.Fatalf("Dump cancelled while retrying chunk for %s: %v", tablename, tm.ctx.Err())
+				case <-time.After(time.Duration(attempt) * time.Second):
+				}
 			}
-		}
-		if parseErr != nil {
-			log.Fatalf("Error parsing chunk for %s: %s", chunk.Task.Table.GetFullName(), parseErr.Error())
-		}
-		if _, err := buffer.Write(chunkStage.Bytes()); err != nil {
-			log.Fatalf("Error writing dump file for %s: %v", tablename, err)
+			if parseErr != nil {
+				log.Fatalf("Error parsing chunk for %s: %s", chunk.Task.Table.GetFullName(), parseErr.Error())
+			}
+			if _, err := buffer.Write(chunkStage.Bytes()); err != nil {
+				log.Fatalf("Error writing dump file for %s: %v", tablename, err)
+			}
 		}
 		// Flush before counting the chunk as completed: a table is only marked
 		// done in metadata once every one of its chunks has been handed to the OS.

--- a/test/test-versions.sh
+++ b/test/test-versions.sh
@@ -67,7 +67,13 @@ seed() {
             UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t1,
            (SELECT 0 n UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
             UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) t2,
-           (SELECT 0 n UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4) t3;"
+           (SELECT 0 n UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4) t3;
+    CREATE TABLE matrix.keyless (
+      name VARCHAR(64) NOT NULL,
+      payload TEXT
+    ) ENGINE=InnoDB;
+    INSERT INTO matrix.keyless
+      SELECT CONCAT('k-', id), REPEAT('x', 2048) FROM matrix.items LIMIT 200;"
 }
 
 run_version() {
@@ -82,14 +88,17 @@ run_version() {
   echo "   server: $server_version"
 
   seed "$v"
-  local rows_before
+  local rows_before keyless_before
   rows_before=$(msql "$v" "SELECT COUNT(*) FROM matrix.items;")
+  keyless_before=$(msql "$v" "SELECT COUNT(*) FROM matrix.keyless;")
 
-  # 1. Dump with GTID capture + checksums
+  # 1. Dump with GTID capture + checksums. matrix.keyless (no PK) exercises
+  #    the single-chunk streaming path.
   $GODUMP --mysql-host 127.0.0.1 --mysql-port "$port" \
     --mysql-user root --mysql-password s3cr3t \
     --databases matrix --destination "$dest" \
     --threads 2 --chunk-size 100 \
+    --tables-without-uniquekey single-chunk \
     --get-master-status --checksum --add-drop-table \
     --quiet --execute
 
@@ -101,13 +110,16 @@ run_version() {
   $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
     --directory "$dest" --workers 2 --verify --quiet
 
-  local rows_after
+  local rows_after keyless_after
   rows_after=$(msql "$v" "SELECT COUNT(*) FROM matrix.items;")
   [[ "$rows_after" == "$rows_before" ]] \
     || { echo "   FAIL: rows $rows_before -> $rows_after after restore"; return 1; }
+  keyless_after=$(msql "$v" "SELECT COUNT(*) FROM matrix.keyless;")
+  [[ "$keyless_after" == "$keyless_before" ]] \
+    || { echo "   FAIL: keyless rows $keyless_before -> $keyless_after after restore"; return 1; }
 
   # 3. --skip-binlog: reload must leave gtid_executed untouched
-  msql "$v" "TRUNCATE TABLE matrix.items;"
+  msql "$v" "TRUNCATE TABLE matrix.items; TRUNCATE TABLE matrix.keyless;"
   local gtid_before gtid_after
   gtid_before=$(msql "$v" "SELECT @@global.gtid_executed;")
   $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
@@ -130,7 +142,7 @@ run_version() {
 
   # 5. --set-gtid-purged must REFUSE while gtid_executed exceeds the dump set
   #    (all the binlogged seed/drop/restore activity above is "beyond" it).
-  msql "$v" "TRUNCATE TABLE matrix.items;"
+  msql "$v" "TRUNCATE TABLE matrix.items; TRUNCATE TABLE matrix.keyless;"
   if $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
       --directory "$dest" --workers 2 --data-only --set-gtid-purged --force --quiet 2>"$dest/refusal.log"; then
     echo "   FAIL: --set-gtid-purged did not refuse a target with extra GTIDs"; return 1
@@ -143,7 +155,7 @@ run_version() {
   local reset="RESET MASTER"
   case "$v" in 84|9) reset="RESET BINARY LOGS AND GTIDS" ;; esac
   msql "$v" "$reset;"
-  msql "$v" "SET SESSION sql_log_bin=0; TRUNCATE TABLE matrix.items;"
+  msql "$v" "SET SESSION sql_log_bin=0; TRUNCATE TABLE matrix.items; TRUNCATE TABLE matrix.keyless;"
   $GOLOAD --host 127.0.0.1 --port "$port" --user root --password s3cr3t \
     --directory "$dest" --workers 2 --data-only --skip-binlog --set-gtid-purged --quiet
 


### PR DESCRIPTION
## Summary

Production-readiness review focused on **large tables and databases** — everything so far was validated on small Docker datasets, so this pass hunted for things that only break at size. Two real fixes and the documentation to go with them:

- **Single-chunk tables are now streamed, not staged in RAM.** Every chunk was staged in a `bytes.Buffer` before being written (for retry safety) — which meant a *single-chunk* table (keyless, UUID/VARCHAR PK, or composite PK — anything without a single-column integer NOT NULL key) staged the **entire table in memory**. The 148MB `chaos.notes` incident was the miniature version; a multi-GB keyless table would OOM the dump host. Single chunks now write straight through to the file. Trade-off: no transparent retry once bytes are on disk (parse errors abort the dump), which matches the existing behaviour for non-retryable errors.
- **`--lock-wait-timeout` (new flag, default 60s).** MySQL's default `lock_wait_timeout` is one year, and FTWRL queues behind any long-running statement while every query issued *after* it queues behind FTWRL — so one slow query could previously turn a dump into a server-wide stall with no bound. The lock connection now sets a session timeout, and error 1205 gets an actionable message (check `SHOW PROCESSLIST`, retry when quiet, or raise the flag).
- **>1GB single-chunk warning** at chunk creation, so "why is this table so slow / one file" is answered up front.

## Docs

- README: memory model for both sides (dump: `threads × chunk bytes` staged; load: `workers × statement size`, plus the target server's parse cost — with the real OOM anecdote), the single-column integer key requirement spelled out in `--tables-without-uniquekey`, and the new flag.
- **`docs/SCALE-TEST-PLAN.md`**: tiered plan for closing the "only tested small" gap — Tier 1 correctness/survival on 100GB+ mixed-schema data (memory ceilings, sparse keys, negative/BIGINT-edge keys, kill+resume, live seeding with concurrent writes), Tier 2 production behaviour (busy-primary lock abort, long-snapshot history-list impact, network/disk failures), Tier 3 tuning tables. Includes a suggested sysbench-based rig with fixed container memory limits so OOM behaviour is deterministic.

## Testing

- Matrix seed gains a keyless TEXT table so the single-chunk **streaming** path is exercised end-to-end per version (dump → drop-database → restore → row-count assertions on both tables). Verified live against MySQL 8.0.45: PASS.
- Unit suites pass; vet/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)