### PR TITLE
Dump triggers, stored routines, and events (--triggers / --routines / --events / --skip-definer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,11 @@ go-dump --ini-file /etc/go-dump/primary.ini --databases myapp --destination /bac
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--destination` | — | **Required.** Directory to write dump files. Created if it does not exist. |
-| `--add-drop-table` | false | Prepend `DROP TABLE IF EXISTS` before each `CREATE TABLE`. |
+| `--add-drop-table` | false | Prepend `DROP TABLE IF EXISTS` before each `CREATE TABLE` (and `DROP ... IF EXISTS` before each trigger/routine/event). |
+| `--triggers` | false | Dump triggers for the dumped tables → `<schema>.<table>-triggers.sql`. |
+| `--routines` | false | Dump stored procedures and functions for the dumped schemas → `<schema>-routines.sql`. |
+| `--events` | false | Dump events for the dumped schemas → `<schema>-events.sql`. |
+| `--skip-definer` | false | Strip `DEFINER=user@host` from trigger/routine/event definitions so they load on targets where the definer account does not exist. |
 | `--skip-use-database` | false | Omit `USE \`schema\`` statements from chunk files. |
 | `--compress` | false | Gzip-compress output files (`.sql.gz`). |
 | `--compress-level` | 1 | Compression level 1 (fastest) to 9 (smallest). |
@@ -447,6 +451,38 @@ go-dump \
 # Output files: myapp.orders-thread0.sql.gz, myapp.orders-definition.sql.gz, etc.
 ```
 
+### Dump with triggers, stored routines, and events
+
+```bash
+go-dump \
+  --ini-file /etc/go-dump/prod.ini \
+  --databases myapp \
+  --destination /backups/myapp \
+  --triggers \
+  --routines \
+  --events \
+  --skip-definer \
+  --execute
+# Extra output files:
+#   myapp.orders-triggers.sql   one per table that has triggers
+#   myapp-routines.sql          procedures + functions, one per schema
+#   myapp-events.sql            events, one per schema
+# metadata.json records the counts under "objects".
+```
+
+- Definitions are wrapped in mysqldump-style `sql_mode` / charset guards and
+  `DELIMITER ;;` blocks — they restore with go-load or the plain `mysql` client.
+- `--skip-definer` strips `DEFINER=user@host` so objects load on targets where
+  the definer account does not exist (the most common restore failure —
+  without it the target needs the same accounts or `CREATE` fails with
+  errno 1449). Objects are then created with the loading user as definer.
+- go-load applies triggers **after** the table data, so audit/history triggers
+  do not fire once per restored row.
+- Events restore with their original `ENABLE`/`DISABLE` status; go-dump and
+  go-load never touch the target's `event_scheduler` setting.
+- Missing privileges (`SHOW_ROUTINE`, `EVENT`, `TRIGGER`) skip the affected
+  object with a warning instead of failing the dump.
+
 ### Large table — tune chunk size
 
 For an 8M-row table dumped with 4 threads:
@@ -504,7 +540,10 @@ A dump of `myapp.orders` with 4 threads produces:
 ├── myapp.orders-thread2.sql               # rows assigned to worker 2
 ├── myapp.orders-thread3.sql               # rows assigned to worker 3
 ├── myapp.customers-definition.sql
-└── myapp.customers.sql                    # tables without a PK produce a single file
+├── myapp.customers.sql                    # tables without a PK produce a single file
+├── myapp.orders-triggers.sql              # triggers, per table (--triggers)
+├── myapp-routines.sql                     # procedures + functions, per schema (--routines)
+└── myapp-events.sql                       # events, per schema (--events)
 ```
 
 ### metadata.json
@@ -559,8 +598,11 @@ myapp.customers   918273645     2026-06-10T14:05:32Z
 
 go-load (in this repo) loads files in the right order automatically:
 database creation (`*-schema-create.sql`), then table definitions, then data
-files in parallel — so a dump restores onto a server where the database does
-not exist yet.
+files in parallel, then routines, events, and finally triggers — so a dump
+restores onto a server where the database does not exist yet, and triggers
+never fire while the data is being loaded. go-load understands the
+`DELIMITER ;;` blocks in the object files, so they also restore with the plain
+`mysql` client.
 
 ```bash
 go-load --host target-host --user root --password ... --directory /backups/myapp --workers 4 --verify
@@ -849,17 +891,21 @@ Notes:
 
 Know these before relying on a dump for replica seeding or disaster recovery:
 
-- **Base tables only.** go-dump discovers `TABLE_TYPE = 'BASE TABLE'` — it does
-  **not** dump views, triggers, stored procedures/functions, or events. If your
-  schema uses them, capture them separately and load them after the data:
+- **Views are not dumped.** go-dump discovers `TABLE_TYPE = 'BASE TABLE'` and
+  can carry triggers, routines, and events with `--triggers --routines
+  --events` — but **views** still need a separate pass:
 
   ```bash
-  mysqldump --no-data --no-create-info --routines --events --triggers \
-    -h source-host -u backup -p myapp > myapp-objects.sql
+  mysqldump --no-data --skip-triggers --set-gtid-purged=OFF \
+    -h source-host -u backup -p myapp view1 view2 > myapp-views.sql
   ```
 
-  A replica seeded without its views/routines will error on reads that use
-  them, even though replication itself runs fine.
+  A replica seeded without its views will error on reads that use them, even
+  though replication itself runs fine.
+- **Object definitions are not snapshot-consistent.** Triggers, routines, and
+  events are read with `SHOW CREATE ...`, which is not MVCC-protected — a
+  definition changed in the milliseconds between the lock window and the
+  object read is captured in its newer form.
 - **Users and grants are not dumped** unless `--all-databases
   --include-system-databases` is used (raw `mysql.*` tables, on-prem only —
   never against Cloud SQL/RDS). For portable account DDL, use

--- a/TODO-routines-triggers-events.md
+++ b/TODO-routines-triggers-events.md
@@ -5,108 +5,91 @@ events alongside table schemas and data, and `go-load` applies them in the
 correct order. Follows the mydumper file-naming convention so output stays
 recognizable.
 
-Overall difficulty: **low-to-moderate**. Each object type is a
-`SHOW CREATE ...` (or `information_schema` query) captured on the same
-connection that already holds the consistent snapshot, written through the
-existing buffer/compress pipeline. The subtle parts are definer handling,
-apply ordering on load, and privilege errors.
+Status: **implemented and verified end-to-end** (dump → drop → go-load restore
+against MySQL 8.0.45, plain and compressed, with and without `--skip-definer`).
+Remaining items are at the bottom.
 
-## Design decisions (settle first)
+## Design decisions (settled)
 
-- [ ] Flag shape: separate `--triggers`, `--routines`, `--events` bools
-      (mydumper style) vs. one `--objects=triggers,routines,events` list.
-      Leaning separate bools + keep all off by default (no behavior change).
-- [ ] Definer policy: add `--skip-definer` to strip `DEFINER=...` clauses so
-      dumps load on servers where the definer user doesn't exist (very common
-      restore failure). Decide default: keep definers (faithful) vs. strip.
-- [ ] File naming (proposed, mydumper-compatible):
+- [x] Flag shape: separate `--triggers`, `--routines`, `--events` bools
+      (mydumper style), all off by default — no behavior change for existing
+      users. Also available as INI keys.
+- [x] Definer policy: definitions keep `DEFINER=...` by default (faithful);
+      `--skip-definer` strips it for restores where the definer account does
+      not exist on the target.
+- [x] File naming (mydumper-compatible):
       - `<schema>.<table>-triggers.sql` (triggers grouped per table)
       - `<schema>-routines.sql` (procedures + functions, one file per schema)
       - `<schema>-events.sql` (one file per schema)
-- [ ] Whether `--all-databases` implicitly includes these objects when the
-      flags are set, and how `--tables` filtering interacts with triggers
-      (trigger belongs to a table → dump only triggers of selected tables;
-      routines/events are schema-level → dump when the schema is in scope).
+- [x] Scope: triggers follow the dumped table list (only triggers of selected
+      tables); routines/events are schema-level and dump for every schema
+      that has at least one table in the dump set.
 
-## Dump side (`internal/dump`)
+## Dump side (`internal/dump`) — done
 
-- [ ] `options.go`: add `DumpTriggers`, `DumpRoutines`, `DumpEvents`,
-      `SkipDefiner` to `DumpOptions`; defaults `false` in `GetDumpOptions()`.
-- [ ] `cmd/go-dump/main.go`: wire the new flags, help text, and validation.
-- [ ] `mysql.go`: discovery queries:
-      - Triggers: `SELECT TRIGGER_NAME FROM information_schema.TRIGGERS
-        WHERE TRIGGER_SCHEMA = ? AND EVENT_OBJECT_TABLE = ?` then
-        `SHOW CREATE TRIGGER` per trigger.
-      - Routines: `SELECT ROUTINE_NAME, ROUTINE_TYPE FROM
-        information_schema.ROUTINES WHERE ROUTINE_SCHEMA = ?` then
-        `SHOW CREATE PROCEDURE` / `SHOW CREATE FUNCTION`.
-      - Events: `SELECT EVENT_NAME FROM information_schema.EVENTS
-        WHERE EVENT_SCHEMA = ?` then `SHOW CREATE EVENT`.
-- [ ] Run all object reads on the consistency connection (same place table
-      schemas are captured, before the chunk workers start), so definitions
-      match the data snapshot under `--consistent`.
-- [ ] Capture and emit `sql_mode` / charset context: `SHOW CREATE TRIGGER`
-      returns the trigger's `sql_mode` and charset columns — write
-      `SET @saved_sql_mode…` style guards around each definition (mysqldump
-      does this; skipping it causes subtle restore breakage).
-- [ ] Wrap trigger/routine/event bodies in `DELIMITER ;;` … `DELIMITER ;`
-      blocks in the output files (bodies contain `;`).
-- [ ] Implement `--skip-definer` stripping (regex on the CREATE statement is
-      what mydumper does; handle both `DEFINER=`user`@`host`` and quoted
-      variants).
-- [ ] Write through the existing buffer pipeline so `--compress` and
-      `--dry-run` behave the same as for schema files
-      (see `WriteSchemaCreateSQL` in `taskmanager.go` as the template).
-- [ ] Privilege handling: `SHOW CREATE ...` on routines needs `SELECT` on
-      `mysql.proc` or `SHOW ROUTINE`/definer rights depending on version;
-      events need `EVENT` privilege. Fail with a clear per-object error and a
-      hint, not a mid-dump panic. Decide: hard fail vs. warn-and-skip
-      (mydumper warns; propose warn + non-zero note in metadata).
-- [ ] `metadata.go`: record which object types were dumped (and any skipped
-      due to privileges) so a resume/load knows what to expect.
-- [ ] `resume.go`: object files are small — simplest correct behavior is to
-      re-dump them on resume; make sure resume doesn't choke on the new files.
+- [x] `options.go`: `DumpTriggers`, `DumpRoutines`, `DumpEvents`,
+      `SkipDefiner` on `DumpOptions`, default `false`.
+- [x] `cmd/go-dump/main.go`: flags wired, usage text updated.
+- [x] `ini.go`: `triggers`, `routines`, `events`, `skip-definer` keys.
+- [x] `objects.go` (new): discovery via `information_schema`, capture via
+      `SHOW CREATE TRIGGER/PROCEDURE/FUNCTION/EVENT` with column-name-based
+      scanning (version-safe), trigger `ACTION_ORDER` preserved.
+- [x] mysqldump-style `sql_mode` / `character_set_client` /
+      `collation_connection` save-set-restore guards around each definition;
+      per-event `time_zone` guard.
+- [x] Bodies wrapped in `DELIMITER ;;` … `DELIMITER ;` blocks.
+- [x] `--skip-definer` regex handles backtick/single/double-quoted and
+      unquoted user@host plus `CURRENT_USER[()]` (unit-tested).
+- [x] Output goes through the shared buffer pipeline — `--compress` works.
+- [x] `--add-drop-table` also emits versioned-comment `DROP ... IF EXISTS`
+      before each object.
+- [x] Privileges: discovery/`SHOW CREATE` failures warn and skip the object;
+      file-write failures abort the dump (same policy as schema files).
+- [x] `metadata.json`: `"objects": {"triggers": N, "routines": N, "events": N}`.
+- [x] Resume: object files are rewritten only for tables still in the task
+      pool; files from the prior run remain on disk (same behavior as
+      `-definition.sql` files).
 
-## Load side (`internal/load`)
+## Load side (`internal/load`) — done
 
-- [ ] `importer.go`: recognize the new file patterns and order phases:
-      1. `*-schema-create.sql` (exists today)
-      2. table definitions (exists today)
-      3. data (exists today)
-      4. `*-routines.sql`, `*-events.sql` (schema-level, after schema create;
-         safe after data)
-      5. `*.<table>-triggers.sql` **after that table's data is loaded** —
-         loading triggers before data would fire them during import.
-- [ ] `DELIMITER` is a client-side construct — the loader must parse the
-      `;;`-delimited statements itself (or write files without DELIMITER and
-      split on a marker comment). Decide format with the dump side.
-- [ ] Events: decide whether to load with `SET GLOBAL event_scheduler` note
-      or leave scheduler state alone (leave alone; document it).
-- [ ] Loading into a replica-seeding target: routines/triggers/events execute
-      under the session `sql_log_bin=0` path already used for data — confirm
-      the skip-binlog path covers these files too (`skipbinlog_test.go`).
+- [x] `importer.go` phases: schema-create → definitions → data (parallel) →
+      routines → events → triggers (serial, only after all data succeeded).
+- [x] `parseStatements` understands client-side `DELIMITER` directives
+      (case-insensitive, multi-char delimiters, partial-match restore,
+      EOF without trailing newline) — object files also restore with the
+      plain `mysql` client.
+- [x] `--data-only` skips object files along with schema files.
+- [x] `--skip-binlog` covers object files (same `loadFile` path sets
+      `SQL_LOG_BIN=0` per connection).
+- [x] Resume (`load-state.json`) tracks object files like any other file.
 
-## Tests
+## Tests — done
 
-- [ ] Unit: definer-stripping regex table test (quoted/unquoted, weird hosts).
-- [ ] Unit: file-pattern ordering in the importer (trigger file sorts after
-      its table's data).
-- [ ] Integration (existing docker test harness in `test/`): create a proc,
-      function, trigger, and event in the seed schema; dump; load into a
-      clean instance; assert all four exist and the trigger did not fire
-      during load (row counts match source).
-- [ ] Privilege test: dump as a user without `EVENT` privilege → warn path.
+- [x] Unit: definer-stripping table test (quoted/unquoted/CURRENT_USER/
+      embedded backticks/inside-string non-match).
+- [x] Unit: DELIMITER parsing (trigger body, `$$`, case-insensitivity,
+      partial-match restore, `;;` inside strings, EOF handling, exact
+      go-dump file shape).
+- [x] Unit: `findFiles` ordering and post-flagging, plain and compressed.
+- [x] Manual end-to-end vs MySQL 8.0.45: table + trigger + procedure +
+      function + DISABLED event; dump; DROP DATABASE; go-load restore.
+      Verified: trigger did **not** fire during load (audit-row canary),
+      event still DISABLED, routines callable, trigger fires post-restore.
 
-## Docs
+## Docs — done
 
-- [ ] README: new flags with examples, file-naming table, definer caveat,
-      load-order explanation.
-- [ ] `docs/` replica-seeding walkthrough: note that triggers are applied
-      after data and binlog-skipped during seed.
+- [x] README: flags table, object-dump example, output-files tree, restore
+      ordering, Limitations rewritten (views still not dumped; object reads
+      not MVCC-consistent).
+- [x] `docs/REPLICA-SEEDING-WALKTHROUGH.md`: step 5 now uses the native
+      flags; mysqldump remains only for views.
 
-## Explicitly out of scope (this pass)
+## Remaining / follow-ups
 
-- Views (worth doing later — they have their own ordering problem:
-  view-of-view dependencies; mydumper does two-pass "temp table then view").
-- `--no-data` schema-only mode changes beyond what falls out naturally.
-- Grants/users (`SHOW GRANTS` dumping is a separate feature).
+- [ ] Add trigger/routine/event coverage to `test/test-versions.sh` so the
+      5.7/8.0/8.4/9 matrix exercises the object path automatically.
+- [ ] Views (separate feature — needs two-pass create-or-replace ordering for
+      view-on-view dependencies, like mydumper's temp-table trick).
+- [ ] Grants/users (`SHOW GRANTS` dumping — separate feature).
+- [ ] Optional: `--skip-definer` equivalent on the **load** side (strip while
+      loading third-party dumps).

--- a/TODO-routines-triggers-events.md
+++ b/TODO-routines-triggers-events.md
@@ -1,0 +1,112 @@
+# TODO: Dump events, stored procedures/functions, and triggers
+
+Goal: `go-dump` can optionally dump triggers, stored procedures, functions, and
+events alongside table schemas and data, and `go-load` applies them in the
+correct order. Follows the mydumper file-naming convention so output stays
+recognizable.
+
+Overall difficulty: **low-to-moderate**. Each object type is a
+`SHOW CREATE ...` (or `information_schema` query) captured on the same
+connection that already holds the consistent snapshot, written through the
+existing buffer/compress pipeline. The subtle parts are definer handling,
+apply ordering on load, and privilege errors.
+
+## Design decisions (settle first)
+
+- [ ] Flag shape: separate `--triggers`, `--routines`, `--events` bools
+      (mydumper style) vs. one `--objects=triggers,routines,events` list.
+      Leaning separate bools + keep all off by default (no behavior change).
+- [ ] Definer policy: add `--skip-definer` to strip `DEFINER=...` clauses so
+      dumps load on servers where the definer user doesn't exist (very common
+      restore failure). Decide default: keep definers (faithful) vs. strip.
+- [ ] File naming (proposed, mydumper-compatible):
+      - `<schema>.<table>-triggers.sql` (triggers grouped per table)
+      - `<schema>-routines.sql` (procedures + functions, one file per schema)
+      - `<schema>-events.sql` (one file per schema)
+- [ ] Whether `--all-databases` implicitly includes these objects when the
+      flags are set, and how `--tables` filtering interacts with triggers
+      (trigger belongs to a table → dump only triggers of selected tables;
+      routines/events are schema-level → dump when the schema is in scope).
+
+## Dump side (`internal/dump`)
+
+- [ ] `options.go`: add `DumpTriggers`, `DumpRoutines`, `DumpEvents`,
+      `SkipDefiner` to `DumpOptions`; defaults `false` in `GetDumpOptions()`.
+- [ ] `cmd/go-dump/main.go`: wire the new flags, help text, and validation.
+- [ ] `mysql.go`: discovery queries:
+      - Triggers: `SELECT TRIGGER_NAME FROM information_schema.TRIGGERS
+        WHERE TRIGGER_SCHEMA = ? AND EVENT_OBJECT_TABLE = ?` then
+        `SHOW CREATE TRIGGER` per trigger.
+      - Routines: `SELECT ROUTINE_NAME, ROUTINE_TYPE FROM
+        information_schema.ROUTINES WHERE ROUTINE_SCHEMA = ?` then
+        `SHOW CREATE PROCEDURE` / `SHOW CREATE FUNCTION`.
+      - Events: `SELECT EVENT_NAME FROM information_schema.EVENTS
+        WHERE EVENT_SCHEMA = ?` then `SHOW CREATE EVENT`.
+- [ ] Run all object reads on the consistency connection (same place table
+      schemas are captured, before the chunk workers start), so definitions
+      match the data snapshot under `--consistent`.
+- [ ] Capture and emit `sql_mode` / charset context: `SHOW CREATE TRIGGER`
+      returns the trigger's `sql_mode` and charset columns — write
+      `SET @saved_sql_mode…` style guards around each definition (mysqldump
+      does this; skipping it causes subtle restore breakage).
+- [ ] Wrap trigger/routine/event bodies in `DELIMITER ;;` … `DELIMITER ;`
+      blocks in the output files (bodies contain `;`).
+- [ ] Implement `--skip-definer` stripping (regex on the CREATE statement is
+      what mydumper does; handle both `DEFINER=`user`@`host`` and quoted
+      variants).
+- [ ] Write through the existing buffer pipeline so `--compress` and
+      `--dry-run` behave the same as for schema files
+      (see `WriteSchemaCreateSQL` in `taskmanager.go` as the template).
+- [ ] Privilege handling: `SHOW CREATE ...` on routines needs `SELECT` on
+      `mysql.proc` or `SHOW ROUTINE`/definer rights depending on version;
+      events need `EVENT` privilege. Fail with a clear per-object error and a
+      hint, not a mid-dump panic. Decide: hard fail vs. warn-and-skip
+      (mydumper warns; propose warn + non-zero note in metadata).
+- [ ] `metadata.go`: record which object types were dumped (and any skipped
+      due to privileges) so a resume/load knows what to expect.
+- [ ] `resume.go`: object files are small — simplest correct behavior is to
+      re-dump them on resume; make sure resume doesn't choke on the new files.
+
+## Load side (`internal/load`)
+
+- [ ] `importer.go`: recognize the new file patterns and order phases:
+      1. `*-schema-create.sql` (exists today)
+      2. table definitions (exists today)
+      3. data (exists today)
+      4. `*-routines.sql`, `*-events.sql` (schema-level, after schema create;
+         safe after data)
+      5. `*.<table>-triggers.sql` **after that table's data is loaded** —
+         loading triggers before data would fire them during import.
+- [ ] `DELIMITER` is a client-side construct — the loader must parse the
+      `;;`-delimited statements itself (or write files without DELIMITER and
+      split on a marker comment). Decide format with the dump side.
+- [ ] Events: decide whether to load with `SET GLOBAL event_scheduler` note
+      or leave scheduler state alone (leave alone; document it).
+- [ ] Loading into a replica-seeding target: routines/triggers/events execute
+      under the session `sql_log_bin=0` path already used for data — confirm
+      the skip-binlog path covers these files too (`skipbinlog_test.go`).
+
+## Tests
+
+- [ ] Unit: definer-stripping regex table test (quoted/unquoted, weird hosts).
+- [ ] Unit: file-pattern ordering in the importer (trigger file sorts after
+      its table's data).
+- [ ] Integration (existing docker test harness in `test/`): create a proc,
+      function, trigger, and event in the seed schema; dump; load into a
+      clean instance; assert all four exist and the trigger did not fire
+      during load (row counts match source).
+- [ ] Privilege test: dump as a user without `EVENT` privilege → warn path.
+
+## Docs
+
+- [ ] README: new flags with examples, file-naming table, definer caveat,
+      load-order explanation.
+- [ ] `docs/` replica-seeding walkthrough: note that triggers are applied
+      after data and binlog-skipped during seed.
+
+## Explicitly out of scope (this pass)
+
+- Views (worth doing later — they have their own ordering problem:
+  view-of-view dependencies; mydumper does two-pass "temp table then view").
+- `--no-data` schema-only mode changes beyond what falls out naturally.
+- Grants/users (`SHOW GRANTS` dumping is a separate feature).

--- a/cmd/go-dump/main.go
+++ b/cmd/go-dump/main.go
@@ -29,7 +29,7 @@ func printOption(w io.Writer, f *flag.Flag) {
 
 func PrintUsage(flags map[string]*flag.Flag) {
 	w := tabwriter.NewWriter(os.Stdout, 30, 0, 1, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, "Usage: go-dump  --destination path [--databases str] [--tables str] [--all-databases] [--dry-run | --execute] [--help] [--debug] [--quiet] [--version] [--lock-tables] [--consistent] [--isolation-level str] [--channel-buffer-size num] [--chunk-size num] [--tables-without-uniquekey str] [--threads num] [--mysql-user str] [--mysql-password str] [--mysql-host str] [--mysql-port num] [--mysql-socket path] [--add-drop-table] [--get-master-status] [--get-slave-status] [--output-chunk-size num] [--skip-use-database] [--compress] [--compress-level num] [--where str] [--ini-file str]")
+	fmt.Fprintln(w, "Usage: go-dump  --destination path [--databases str] [--tables str] [--all-databases] [--dry-run | --execute] [--help] [--debug] [--quiet] [--version] [--lock-tables] [--consistent] [--isolation-level str] [--channel-buffer-size num] [--chunk-size num] [--tables-without-uniquekey str] [--threads num] [--mysql-user str] [--mysql-password str] [--mysql-host str] [--mysql-port num] [--mysql-socket path] [--add-drop-table] [--triggers] [--routines] [--events] [--skip-definer] [--get-master-status] [--get-slave-status] [--output-chunk-size num] [--skip-use-database] [--compress] [--compress-level num] [--where str] [--ini-file str]")
 	fmt.Fprintln(w, "go-dump dumps a database or a table from a MySQL server and creates SQL statements to recreate each table. One file per table per thread is written to the destination directory.")
 	fmt.Fprint(w, "Example: go-dump --destination /tmp/dbdump --databases mydb --mysql-user myuser --mysql-password password\n\n")
 	fmt.Fprint(w, "Options description\n\n")
@@ -49,7 +49,7 @@ func PrintUsage(flags map[string]*flag.Flag) {
 		printOption(w, flags[opt])
 	}
 	fmt.Fprintln(w, "\n# Output options:")
-	for _, opt := range []string{"destination", "add-drop-table", "get-master-status", "get-slave-status", "output-chunk-size", "statement-size", "skip-use-database"} {
+	for _, opt := range []string{"destination", "add-drop-table", "triggers", "routines", "events", "skip-definer", "get-master-status", "get-slave-status", "output-chunk-size", "statement-size", "skip-use-database"} {
 		printOption(w, flags[opt])
 	}
 	w.Flush()
@@ -91,7 +91,11 @@ func main() {
 	flag.BoolVar(&dumpOptions.SkipUseDatabase, "skip-use-database", false, "Omit USE \"database\" statements from output files.")
 	flag.BoolVar(&dumpOptions.GetMasterStatus, "get-master-status", false, "Record the binary log position at dump time.")
 	flag.BoolVar(&dumpOptions.GetSlaveStatus, "get-slave-status", false, "Record the replica status at dump time.")
-	flag.BoolVar(&dumpOptions.AddDropTable, "add-drop-table", false, "Prepend DROP TABLE IF EXISTS before each CREATE TABLE.")
+	flag.BoolVar(&dumpOptions.AddDropTable, "add-drop-table", false, "Prepend DROP TABLE IF EXISTS before each CREATE TABLE (and DROP ... IF EXISTS before triggers/routines/events).")
+	flag.BoolVar(&dumpOptions.DumpTriggers, "triggers", false, "Dump triggers for the dumped tables (<schema>.<table>-triggers.sql).")
+	flag.BoolVar(&dumpOptions.DumpRoutines, "routines", false, "Dump stored procedures and functions for the dumped schemas (<schema>-routines.sql).")
+	flag.BoolVar(&dumpOptions.DumpEvents, "events", false, "Dump events for the dumped schemas (<schema>-events.sql).")
+	flag.BoolVar(&dumpOptions.SkipDefiner, "skip-definer", false, "Strip DEFINER=... from trigger/routine/event definitions so they load where the definer account does not exist.")
 	flag.BoolVar(&dumpOptions.Checksum, "checksum", false, "Run CHECKSUM TABLE after dump and write checksums.txt.")
 	flag.BoolVar(&dumpOptions.Resume, "resume", false, "Resume a previous dump: skip completed tables and clean partial files.")
 	flag.BoolVar(&dumpOptions.Compress, "compress", false, "Compress output files with gzip.")

--- a/docs/REPLICA-SEEDING-WALKTHROUGH.md
+++ b/docs/REPLICA-SEEDING-WALKTHROUGH.md
@@ -42,8 +42,10 @@ Three things this told us:
   and **survives** `STOP REPLICA` and `RESET MASTER`. We will not need the
   replication password at all. (`RESET REPLICA ALL` would wipe it — don't.)
 - **Databases to reseed**: `ca_analysis chaos go_bills roll_back sakila`.
-- **Objects go-dump won't carry**: 9 views, 7 routines, 6 triggers, 1 event
-  (`information_schema.views/routines/triggers/events`). Step 6 handles them.
+- **Non-table objects**: 9 views, 7 routines, 6 triggers, 1 event
+  (`information_schema.views/routines/triggers/events`). Routines, triggers,
+  and events ride along with `--triggers --routines --events`; views need the
+  extra pass in step 5.
 
 ## Step 1 — Dump the primary with GTID capture
 
@@ -153,11 +155,23 @@ INFO gtid_purged set to the dump's snapshot GTID set. Next: CHANGE REPLICATION
 
 ## Step 5 — Views, routines, triggers, events
 
-go-dump moves base tables only. This schema had 9 views, 7 routines,
-6 triggers, 1 event — without them the replica errors on any read through a
-view, even though replication itself would run fine. Copy them with
-mysqldump, **loading with binlog disabled** for the same errant-GTID reason
-as step 3.
+This schema had 9 views, 7 routines, 6 triggers, 1 event — without them the
+replica errors on any read through a view, even though replication itself
+would run fine.
+
+go-dump now carries routines, triggers, and events natively: add
+`--triggers --routines --events` (and usually `--skip-definer`) to the
+step-1 dump, and go-load applies them in the right order — triggers after
+the data, so they don't fire during the restore — on the same
+`--skip-binlog` connections, keeping the replica's GTID history clean:
+
+```bash
+go-dump ... --triggers --routines --events --skip-definer --execute
+go-load ... --skip-binlog --set-gtid-purged --directory /backups/seed
+```
+
+That leaves only **views**, which still need a mysqldump pass, **loading
+with binlog disabled** for the same errant-GTID reason as step 3.
 
 Two mysqldump traps we hit doing this for real:
 

--- a/internal/dump/dumper.go
+++ b/internal/dump/dumper.go
@@ -131,6 +131,9 @@ func Run(ctx context.Context, opts *DumpOptions) {
 		// dump (or a resumed one) is restorable as far as it got.
 		taskManager.WriteSchemaCreateSQL()
 		taskManager.WriteTablesSQL(opts.AddDropTable)
+		if counts := taskManager.WriteObjectsSQL(); counts != nil {
+			meta.SetObjects(counts)
+		}
 
 		taskManager.CreateChunksWaitGroup.Add(1)
 		go taskManager.CreateChunks(dbchunks)

--- a/internal/dump/ini.go
+++ b/internal/dump/ini.go
@@ -121,6 +121,14 @@ func parseIniOptions(section *ini.Section, do *DumpOptions, flagSet map[string]b
 			do.GetSlaveStatus, errBool = strconv.ParseBool(key.Value())
 		case "add-drop-table":
 			do.AddDropTable, errBool = strconv.ParseBool(key.Value())
+		case "triggers":
+			do.DumpTriggers, errBool = strconv.ParseBool(key.Value())
+		case "routines":
+			do.DumpRoutines, errBool = strconv.ParseBool(key.Value())
+		case "events":
+			do.DumpEvents, errBool = strconv.ParseBool(key.Value())
+		case "skip-definer":
+			do.SkipDefiner, errBool = strconv.ParseBool(key.Value())
 		case "checksum":
 			do.Checksum, errBool = strconv.ParseBool(key.Value())
 		case "resume":

--- a/internal/dump/metadata.go
+++ b/internal/dump/metadata.go
@@ -39,6 +39,7 @@ type DumpMetadata struct {
 	BinlogPosition int              `json:"binlog_position,omitempty"`
 	GTIDSet        string           `json:"gtid_set,omitempty"`
 	CharacterSet   string           `json:"character_set"`
+	Objects        map[string]int   `json:"objects,omitempty"` // "triggers"/"routines"/"events" -> count dumped
 	Tables         []*TableMetadata `json:"tables"`
 
 	mu   sync.Mutex
@@ -139,6 +140,14 @@ func (m *DumpMetadata) SetChecksum(schema, name string, checksum int64) {
 			break
 		}
 	}
+}
+
+// SetObjects records how many triggers/routines/events were dumped.
+func (m *DumpMetadata) SetObjects(counts map[string]int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Objects = counts
+	_ = m.write()
 }
 
 // Complete marks the dump finished and writes the final metadata file.

--- a/internal/dump/objects.go
+++ b/internal/dump/objects.go
@@ -1,0 +1,388 @@
+package dump
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/ChaosHour/go-dump/internal/log"
+)
+
+// Object dumping: triggers, stored procedures/functions, and events.
+//
+// Each object is captured with SHOW CREATE ... and written mysqldump-style:
+// sql_mode / charset guards around every definition, and DELIMITER ;; blocks
+// because the bodies contain semicolons. File naming follows mydumper:
+//
+//	<schema>.<table>-triggers.sql   triggers, grouped per table
+//	<schema>-routines.sql           procedures and functions, per schema
+//	<schema>-events.sql             events, per schema
+//
+// go-load applies these after all data files, so triggers never fire during
+// the restore.
+//
+// Object definitions are not MVCC-protected: unlike table data, a definition
+// changed between the lock window and this read is captured in its newer
+// form. The window is the few milliseconds between snapshot and these reads.
+
+// definerRe matches the DEFINER clause of CREATE TRIGGER/PROCEDURE/FUNCTION/
+// EVENT statements: DEFINER=CURRENT_USER, DEFINER=user@host, with the user and
+// host parts optionally backtick-, single- or double-quoted.
+var definerRe = regexp.MustCompile(`(?i)\s+DEFINER\s*=\s*(?:CURRENT_USER(?:\(\))?|` +
+	"(?:`(?:[^`]|``)*`" + `|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|[0-9A-Za-z$_]+)` +
+	`\s*@\s*` +
+	"(?:`(?:[^`]|``)*`" + `|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|[0-9A-Za-z$_.%-]+))`)
+
+// StripDefiner removes the DEFINER=... clause from a CREATE statement so the
+// object loads on servers where the definer account does not exist. The object
+// is then created with the invoker as definer.
+func StripDefiner(stmt string) string {
+	return definerRe.ReplaceAllString(stmt, "")
+}
+
+// showCreateObject runs a SHOW CREATE ... query and returns the single result
+// row keyed by lower-cased column name. Columns that are NULL (e.g. the body
+// when the dump user lacks privileges to see it) are absent from the map.
+func showCreateObject(db *sql.DB, query string) (map[string]string, error) {
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("no rows returned")
+	}
+	vals := make([]sql.NullString, len(cols))
+	ptrs := make([]interface{}, len(cols))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+	if err := rows.Scan(ptrs...); err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(cols))
+	for i, c := range cols {
+		if vals[i].Valid {
+			out[strings.ToLower(c)] = vals[i].String
+		}
+	}
+	return out, nil
+}
+
+// writeObjectGuardsHeader saves the session state that each definition below
+// overrides, mirroring mysqldump so definitions execute under the sql_mode and
+// charset they were created with, not the restore session's.
+func writeObjectGuardsHeader(b *Buffer) {
+	fmt.Fprintf(b, "/*!50003 SET @saved_cs_client = @@character_set_client */;\n")
+	fmt.Fprintf(b, "/*!50003 SET @saved_col_connection = @@collation_connection */;\n")
+	fmt.Fprintf(b, "/*!50003 SET @saved_sql_mode = @@sql_mode */;\n")
+}
+
+func writeObjectGuardsFooter(b *Buffer) {
+	fmt.Fprintf(b, "/*!50003 SET sql_mode = @saved_sql_mode */;\n")
+	fmt.Fprintf(b, "/*!50003 SET character_set_client = @saved_cs_client */;\n")
+	fmt.Fprintf(b, "/*!50003 SET collation_connection = @saved_col_connection */;\n")
+}
+
+// writeObjectDefinition writes one object's creation-context SETs, an optional
+// DROP, and the CREATE statement wrapped in DELIMITER ;; (bodies contain
+// semicolons; go-load and the mysql client both understand the directive).
+func writeObjectDefinition(b *Buffer, def map[string]string, createKey, dropSQL string, skipDefiner bool) {
+	if cs := def["character_set_client"]; cs != "" {
+		fmt.Fprintf(b, "/*!50003 SET character_set_client = %s */;\n", cs)
+	}
+	if col := def["collation_connection"]; col != "" {
+		fmt.Fprintf(b, "/*!50003 SET collation_connection = %s */;\n", col)
+	}
+	// sql_mode can legitimately be the empty string; write it either way so
+	// the definition never inherits the restore session's mode.
+	sqlMode := def["sql_mode"]
+	fmt.Fprintf(b, "/*!50003 SET sql_mode = '%s' */;\n", strings.ReplaceAll(sqlMode, "'", "''"))
+
+	if dropSQL != "" {
+		fmt.Fprintf(b, "%s;\n", dropSQL)
+	}
+	createSQL := def[createKey]
+	if skipDefiner {
+		createSQL = StripDefiner(createSQL)
+	}
+	fmt.Fprintf(b, "DELIMITER ;;\n%s;;\nDELIMITER ;\n", createSQL)
+}
+
+// WriteObjectsSQL dumps triggers, routines, and events per the Dump* options.
+// It returns per-kind counts of objects written, or nil when no object dumping
+// was requested. Discovery or SHOW CREATE failures (typically missing
+// privileges) skip the object with a warning; file-write failures abort the
+// dump, exactly like the schema files.
+func (tm *TaskManager) WriteObjectsSQL() map[string]int {
+	opts := tm.DumpOptions
+	if !opts.DumpTriggers && !opts.DumpRoutines && !opts.DumpEvents {
+		return nil
+	}
+	counts := make(map[string]int)
+	if opts.DumpTriggers {
+		counts["triggers"] = tm.writeTriggers()
+	}
+	if opts.DumpRoutines {
+		counts["routines"] = tm.writeRoutines()
+	}
+	if opts.DumpEvents {
+		counts["events"] = tm.writeEvents()
+	}
+	return counts
+}
+
+// schemasInPool returns the sorted distinct schemas of the tables being dumped.
+func (tm *TaskManager) schemasInPool() []string {
+	set := make(map[string]bool)
+	for _, task := range tm.tasksPool {
+		set[task.Table.GetUnescapedSchema()] = true
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// newObjectBuffer opens a dump file for object definitions and writes the
+// shared USE / guard header.
+func (tm *TaskManager) newObjectBuffer(fileName, schema string) (*Buffer, error) {
+	bufferOptions := tm.GetBufferOptions()
+	bufferOptions.Path = filepath.Join(tm.DestinationDir, fileName)
+	buffer, err := NewBuffer(bufferOptions)
+	if err != nil {
+		return nil, err
+	}
+	if !tm.SkipUseDatabase {
+		fmt.Fprintf(buffer, "%s;\n", GetUseDatabaseSQL(escapeIdentifier(schema)))
+	}
+	writeObjectGuardsHeader(buffer)
+	return buffer, nil
+}
+
+// writeTriggers dumps the triggers of every table in the task pool, one
+// <schema>.<table>-triggers.sql file per table that has readable triggers.
+// ACTION_ORDER is preserved so FOLLOWS/PRECEDES chains recreate correctly.
+func (tm *TaskManager) writeTriggers() int {
+	total := 0
+	for _, task := range tm.tasksPool {
+		schema := task.Table.GetUnescapedSchema()
+		table := task.Table.GetUnescapedName()
+
+		names, err := queryStrings(tm.DB, `SELECT TRIGGER_NAME
+			FROM information_schema.TRIGGERS
+			WHERE TRIGGER_SCHEMA = ? AND EVENT_OBJECT_TABLE = ?
+			ORDER BY EVENT_MANIPULATION, ACTION_TIMING, ACTION_ORDER`, schema, table)
+		if err != nil {
+			log.Warningf("Skipping triggers for %s.%s — cannot list them: %v", schema, table, err)
+			continue
+		}
+		if len(names) == 0 {
+			continue
+		}
+
+		var defs []map[string]string
+		for _, name := range names {
+			def, err := showCreateObject(tm.DB, fmt.Sprintf("SHOW CREATE TRIGGER %s.%s",
+				escapeIdentifier(schema), escapeIdentifier(name)))
+			if err != nil || def["sql original statement"] == "" {
+				log.Warningf("Skipping trigger %s.%s — definition not readable (missing TRIGGER privilege?): %v",
+					schema, name, err)
+				continue
+			}
+			defs = append(defs, def)
+		}
+		if len(defs) == 0 {
+			continue
+		}
+
+		buffer, err := tm.newObjectBuffer(fmt.Sprintf("%s.%s-triggers.sql", schema, table), schema)
+		if err != nil {
+			log.Fatalf("Error creating triggers file for %s.%s: %v", schema, table, err)
+		}
+		for _, def := range defs {
+			dropSQL := ""
+			if tm.DumpOptions.AddDropTable {
+				dropSQL = fmt.Sprintf("/*!50032 DROP TRIGGER IF EXISTS %s */", escapeIdentifier(def["trigger"]))
+			}
+			writeObjectDefinition(buffer, def, "sql original statement", dropSQL, tm.DumpOptions.SkipDefiner)
+			total++
+		}
+		writeObjectGuardsFooter(buffer)
+		if err := buffer.Close(); err != nil {
+			log.Fatalf("Error finalising triggers file for %s.%s: %v", schema, table, err)
+		}
+		log.Infof("Dumped %d trigger(s) for %s.%s", len(defs), schema, table)
+	}
+	return total
+}
+
+// writeRoutines dumps stored procedures and functions, one
+// <schema>-routines.sql file per schema that has readable routines. The body
+// column of SHOW CREATE is NULL when the dump user is not the definer and
+// lacks SELECT on mysql.proc (5.7) / SHOW_ROUTINE (8.0) — those are skipped
+// with a warning.
+func (tm *TaskManager) writeRoutines() int {
+	total := 0
+	for _, schema := range tm.schemasInPool() {
+		rows, err := tm.DB.QueryContext(tm.ctx, `SELECT ROUTINE_NAME, ROUTINE_TYPE
+			FROM information_schema.ROUTINES
+			WHERE ROUTINE_SCHEMA = ?
+			ORDER BY ROUTINE_TYPE, ROUTINE_NAME`, schema)
+		if err != nil {
+			log.Warningf("Skipping routines for %s — cannot list them: %v", schema, err)
+			continue
+		}
+		type routine struct{ name, kind string }
+		var routines []routine
+		for rows.Next() {
+			var r routine
+			if err := rows.Scan(&r.name, &r.kind); err != nil {
+				rows.Close()
+				log.Fatalf("Error scanning routine row for %s: %v", schema, err)
+			}
+			routines = append(routines, r)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			log.Warningf("Skipping routines for %s — error listing them: %v", schema, err)
+			continue
+		}
+		if len(routines) == 0 {
+			continue
+		}
+
+		type routineDef struct {
+			def        map[string]string
+			kind, name string
+			createKey  string
+		}
+		var defs []routineDef
+		for _, r := range routines {
+			// ROUTINE_TYPE is PROCEDURE or FUNCTION; it doubles as the SHOW
+			// CREATE keyword and the result column name ("Create Procedure").
+			def, err := showCreateObject(tm.DB, fmt.Sprintf("SHOW CREATE %s %s.%s",
+				r.kind, escapeIdentifier(schema), escapeIdentifier(r.name)))
+			createKey := "create " + strings.ToLower(r.kind)
+			if err != nil || def[createKey] == "" {
+				log.Warningf("Skipping %s %s.%s — body not readable (missing SHOW_ROUTINE/SELECT on mysql.proc?): %v",
+					strings.ToLower(r.kind), schema, r.name, err)
+				continue
+			}
+			defs = append(defs, routineDef{def: def, kind: r.kind, name: r.name, createKey: createKey})
+		}
+		if len(defs) == 0 {
+			continue
+		}
+
+		buffer, err := tm.newObjectBuffer(schema+"-routines.sql", schema)
+		if err != nil {
+			log.Fatalf("Error creating routines file for %s: %v", schema, err)
+		}
+		for _, rd := range defs {
+			dropSQL := ""
+			if tm.DumpOptions.AddDropTable {
+				dropSQL = fmt.Sprintf("/*!50003 DROP %s IF EXISTS %s */", rd.kind, escapeIdentifier(rd.name))
+			}
+			writeObjectDefinition(buffer, rd.def, rd.createKey, dropSQL, tm.DumpOptions.SkipDefiner)
+			total++
+		}
+		writeObjectGuardsFooter(buffer)
+		if err := buffer.Close(); err != nil {
+			log.Fatalf("Error finalising routines file for %s: %v", schema, err)
+		}
+		log.Infof("Dumped %d routine(s) for schema %s", len(defs), schema)
+	}
+	return total
+}
+
+// writeEvents dumps events, one <schema>-events.sql file per schema that has
+// readable events. Each event's time_zone is restored around its definition —
+// schedules are evaluated in the creation time zone. Event scheduler state on
+// the target is deliberately left alone.
+func (tm *TaskManager) writeEvents() int {
+	total := 0
+	for _, schema := range tm.schemasInPool() {
+		names, err := queryStrings(tm.DB, `SELECT EVENT_NAME
+			FROM information_schema.EVENTS
+			WHERE EVENT_SCHEMA = ?
+			ORDER BY EVENT_NAME`, schema)
+		if err != nil {
+			log.Warningf("Skipping events for %s — cannot list them (missing EVENT privilege?): %v", schema, err)
+			continue
+		}
+		if len(names) == 0 {
+			continue
+		}
+
+		var defs []map[string]string
+		for _, name := range names {
+			def, err := showCreateObject(tm.DB, fmt.Sprintf("SHOW CREATE EVENT %s.%s",
+				escapeIdentifier(schema), escapeIdentifier(name)))
+			if err != nil || def["create event"] == "" {
+				log.Warningf("Skipping event %s.%s — definition not readable (missing EVENT privilege?): %v",
+					schema, name, err)
+				continue
+			}
+			defs = append(defs, def)
+		}
+		if len(defs) == 0 {
+			continue
+		}
+
+		buffer, err := tm.newObjectBuffer(schema+"-events.sql", schema)
+		if err != nil {
+			log.Fatalf("Error creating events file for %s: %v", schema, err)
+		}
+		fmt.Fprintf(buffer, "/*!50106 SET @saved_time_zone = @@time_zone */;\n")
+		for _, def := range defs {
+			if tz := def["time_zone"]; tz != "" {
+				fmt.Fprintf(buffer, "/*!50106 SET time_zone = '%s' */;\n", strings.ReplaceAll(tz, "'", "''"))
+			}
+			dropSQL := ""
+			if tm.DumpOptions.AddDropTable {
+				dropSQL = fmt.Sprintf("/*!50106 DROP EVENT IF EXISTS %s */", escapeIdentifier(def["event"]))
+			}
+			writeObjectDefinition(buffer, def, "create event", dropSQL, tm.DumpOptions.SkipDefiner)
+			total++
+		}
+		fmt.Fprintf(buffer, "/*!50106 SET time_zone = @saved_time_zone */;\n")
+		writeObjectGuardsFooter(buffer)
+		if err := buffer.Close(); err != nil {
+			log.Fatalf("Error finalising events file for %s: %v", schema, err)
+		}
+		log.Infof("Dumped %d event(s) for schema %s", len(defs), schema)
+	}
+	return total
+}
+
+// queryStrings runs a single-column query and returns the values.
+func queryStrings(db *sql.DB, query string, args ...interface{}) ([]string, error) {
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}

--- a/internal/dump/objects_test.go
+++ b/internal/dump/objects_test.go
@@ -1,0 +1,79 @@
+package dump
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripDefiner(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{
+			name: "backtick quoted",
+			in:   "CREATE DEFINER=`app`@`10.0.%` TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET @a=1",
+			want: "CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET @a=1",
+		},
+		{
+			name: "unquoted user and host",
+			in:   "CREATE DEFINER=root@localhost PROCEDURE p() BEGIN END",
+			want: "CREATE PROCEDURE p() BEGIN END",
+		},
+		{
+			name: "single quoted",
+			in:   "CREATE DEFINER='app user'@'%' FUNCTION f() RETURNS INT RETURN 1",
+			want: "CREATE FUNCTION f() RETURNS INT RETURN 1",
+		},
+		{
+			name: "current_user",
+			in:   "CREATE DEFINER=CURRENT_USER EVENT ev ON SCHEDULE EVERY 1 DAY DO SET @a=1",
+			want: "CREATE EVENT ev ON SCHEDULE EVERY 1 DAY DO SET @a=1",
+		},
+		{
+			name: "current_user with parens",
+			in:   "CREATE DEFINER = CURRENT_USER() EVENT ev ON SCHEDULE EVERY 1 DAY DO SET @a=1",
+			want: "CREATE EVENT ev ON SCHEDULE EVERY 1 DAY DO SET @a=1",
+		},
+		{
+			name: "spaces around equals",
+			in:   "CREATE DEFINER = `u` @ `h` TRIGGER trg AFTER DELETE ON t FOR EACH ROW SET @a=1",
+			want: "CREATE TRIGGER trg AFTER DELETE ON t FOR EACH ROW SET @a=1",
+		},
+		{
+			name: "backtick with embedded doubled backtick",
+			in:   "CREATE DEFINER=`we``ird`@`%` TRIGGER trg BEFORE UPDATE ON t FOR EACH ROW SET @a=1",
+			want: "CREATE TRIGGER trg BEFORE UPDATE ON t FOR EACH ROW SET @a=1",
+		},
+		{
+			name: "no definer clause unchanged",
+			in:   "CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET @a=1",
+			want: "CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET @a=1",
+		},
+		{
+			name: "definer text inside body string is untouched",
+			// The regex requires whitespace immediately before DEFINER; inside
+			// the string literal the preceding byte is a quote, so no match.
+			in:   "CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET NEW.v = 'DEFINER=`x`@`y` stays'",
+			want: "CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET NEW.v = 'DEFINER=`x`@`y` stays'",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripDefiner(tc.in)
+			if got != tc.want {
+				t.Errorf("StripDefiner(%q)\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripDefinerKeepsRestOfStatement(t *testing.T) {
+	in := "CREATE DEFINER=`u`@`h` PROCEDURE p(IN x INT)\nBEGIN\n  SELECT x;\nEND"
+	got := StripDefiner(in)
+	if !strings.Contains(got, "PROCEDURE p(IN x INT)") || !strings.Contains(got, "SELECT x;") {
+		t.Errorf("body damaged: %q", got)
+	}
+	if strings.Contains(got, "DEFINER") {
+		t.Errorf("DEFINER not removed: %q", got)
+	}
+}

--- a/internal/dump/options.go
+++ b/internal/dump/options.go
@@ -25,6 +25,10 @@ type DumpOptions struct {
 	Consistent            bool
 	Checksum              bool
 	Resume                bool
+	DumpTriggers          bool
+	DumpRoutines          bool // stored procedures and functions
+	DumpEvents            bool
+	SkipDefiner           bool              // strip DEFINER=... from trigger/routine/event definitions
 	WhereConditions       map[string]string // table -> where condition
 	GlobalWhereCondition  string            // fallback for all tables
 	TemporalOptions       TemporalOptions

--- a/internal/load/importer.go
+++ b/internal/load/importer.go
@@ -25,6 +25,7 @@ import (
 type FileLoad struct {
 	Path     string
 	IsSchema bool
+	IsPost   bool // trigger/routine/event file — loaded serially after all data
 }
 
 // Importer loads SQL files produced by go-dump into a MySQL server.
@@ -91,7 +92,7 @@ func (imp *Importer) ImportDirectory(ctx context.Context, dir, pattern string, l
 	// Count data files for progress reporting.
 	var total int64
 	for _, f := range files {
-		if !f.IsSchema {
+		if !f.IsSchema && !f.IsPost {
 			atomic.AddInt64(&total, 1)
 		}
 	}
@@ -122,7 +123,7 @@ func (imp *Importer) ImportDirectory(ctx context.Context, dir, pattern string, l
 	var wg sync.WaitGroup
 
 	for _, f := range files {
-		if f.IsSchema {
+		if f.IsSchema || f.IsPost {
 			continue
 		}
 		name := filepath.Base(f.Path)
@@ -160,6 +161,30 @@ func (imp *Importer) ImportDirectory(ctx context.Context, dir, pattern string, l
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%d file(s) failed:\n  %s", len(errs), strings.Join(errs, "\n  "))
+	}
+
+	// Post-data files (routines, events, triggers): serial, and only after
+	// every data file has loaded — a trigger created before its table's data
+	// would fire for every restored row. Skipped with --data-only, like the
+	// schema files.
+	if !imp.skipSchema {
+		for _, f := range files {
+			if !f.IsPost {
+				continue
+			}
+			name := filepath.Base(f.Path)
+			if ls != nil && ls.HasFile(name) {
+				log.Infof("Resume: skipping %s", name)
+				continue
+			}
+			if err := imp.loadFile(ctx, f.Path); err != nil {
+				return fmt.Errorf("%s: %w", name, err)
+			}
+			if ls != nil {
+				_ = ls.Mark(name)
+			}
+			log.Infof("Loaded: %s", name)
+		}
 	}
 
 	log.Infof("Progress: %d/%d files loaded", atomic.LoadInt64(&done), total)
@@ -267,6 +292,10 @@ func execStream(ctx context.Context, conn *sql.Conn, r io.Reader) error {
 //   - backtick-quoted identifiers (” doubling, no backslash escapes)
 //   - line comments ("-- " per MySQL — the dashes must be followed by
 //     whitespace — and "#") and /* block comments */
+//   - DELIMITER directives (client-side, never sent to the server), so
+//     trigger/routine/event files whose bodies contain semicolons load
+//     correctly. A directive is only recognised on a line with no SQL
+//     before it, matching how go-dump and mysqldump emit them.
 //
 // Comment bytes are kept in the statement text (MySQL accepts leading
 // comments, and /*!...*/ versioned comments are executable), but a segment
@@ -283,6 +312,23 @@ func parseStatements(r io.Reader, cb func(string) error) error {
 	hasSQL := false // statement contains something beyond comments/whitespace
 	dashRun := 0    // consecutive '-' bytes seen outside quotes/comments
 
+	// Statement terminator state. delim is usually ";" but changes via
+	// DELIMITER directives; delimPos counts how many delimiter bytes have
+	// matched so far (multi-byte delimiters match incrementally).
+	delim := []byte{';'}
+	delimPos := 0
+
+	// DELIMITER directive detection. candidate is true while the current line
+	// could still be a directive (no SQL preceded it in the statement); wordPos
+	// tracks case-insensitive matching against "DELIMITER"; once the word plus
+	// whitespace is seen, inDirective captures the rest of the line as the new
+	// delimiter token.
+	const directiveWord = "DELIMITER"
+	candidate := true
+	wordPos := 0
+	inDirective := false
+	var dirBuf []byte
+
 	emit := func() error {
 		s := strings.TrimSpace(stmt.String())
 		stmt.Reset()
@@ -294,12 +340,59 @@ func parseStatements(r io.Reader, cb func(string) error) error {
 		return cb(s)
 	}
 
+	applyDirective := func() {
+		if token := strings.TrimSpace(string(dirBuf)); token != "" {
+			delim = []byte(token)
+		}
+		// The directive line (and any leading whitespace/comments) is consumed;
+		// it is a client instruction, not SQL.
+		stmt.Reset()
+		hasSQL = false
+		inDirective = false
+		candidate = true
+		wordPos = 0
+		dirBuf = dirBuf[:0]
+		delimPos = 0
+	}
+
 	buf := make([]byte, 64*1024)
 	for {
 		n, readErr := r.Read(buf)
 		for i := 0; i < n; i++ {
 			b := buf[i]
 
+			if inDirective {
+				if b == '\n' {
+					applyDirective()
+				} else {
+					dirBuf = append(dirBuf, b)
+				}
+				prev = b
+				continue
+			}
+
+			// Track the DELIMITER keyword at the start of a possible directive
+			// line. The matched letters still flow through normal processing
+			// below, so the statement is intact if the line turns out not to be
+			// a directive (e.g. "DELETE ...").
+			if candidate && inQuote == 0 && !inLineComment && !inBlockComment && !escaped && delimPos == 0 {
+				switch {
+				case wordPos < len(directiveWord) && upperByte(b) == directiveWord[wordPos]:
+					wordPos++
+				case wordPos == len(directiveWord) && (b == ' ' || b == '\t'):
+					inDirective = true
+					dirBuf = dirBuf[:0]
+					prev = b
+					continue // the space is part of the directive, not SQL
+				case wordPos == 0 && (b == ' ' || b == '\t' || b == '\r'):
+					// leading whitespace — line may still be a directive
+				default:
+					candidate = false
+					wordPos = 0
+				}
+			}
+
+		reprocess:
 			switch {
 			case escaped:
 				stmt.WriteByte(b)
@@ -331,10 +424,22 @@ func parseStatements(r io.Reader, cb func(string) error) error {
 					inQuote = 0
 				}
 
-			case b == ';':
-				// Terminating semicolons are not included in the statement body.
-				if err := emit(); err != nil {
-					return err
+			case delimPos > 0 || b == delim[0]:
+				// Delimiter bytes are not included in the statement body.
+				if b == delim[delimPos] {
+					delimPos++
+					if delimPos == len(delim) {
+						delimPos = 0
+						if err := emit(); err != nil {
+							return err
+						}
+					}
+				} else {
+					// Partial delimiter match failed: the matched bytes were
+					// ordinary SQL after all. Restore them and reread b.
+					stmt.Write(delim[:delimPos])
+					delimPos = 0
+					goto reprocess
 				}
 
 			case b == '\'' || b == '"' || b == '`':
@@ -370,6 +475,11 @@ func parseStatements(r io.Reader, cb func(string) error) error {
 			if b != '-' {
 				dashRun = 0
 			}
+			// A new line with no SQL accumulated yet may open a directive.
+			if b == '\n' && inQuote == 0 && !inBlockComment {
+				candidate = !hasSQL
+				wordPos = 0
+			}
 			prev = b
 		}
 		if readErr == io.EOF {
@@ -379,8 +489,22 @@ func parseStatements(r io.Reader, cb func(string) error) error {
 			return fmt.Errorf("read: %w", readErr)
 		}
 	}
-	// Handle trailing content without a terminating semicolon.
+	// Handle a directive or trailing content without a final newline/delimiter.
+	if inDirective {
+		applyDirective()
+	}
+	if delimPos > 0 {
+		stmt.Write(delim[:delimPos])
+	}
 	return emit()
+}
+
+// upperByte upper-cases a single ASCII letter.
+func upperByte(b byte) byte {
+	if b >= 'a' && b <= 'z' {
+		return b - ('a' - 'A')
+	}
+	return b
 }
 
 // splitStatements is a convenience wrapper around parseStatements that
@@ -409,9 +533,10 @@ func isRetryable(err error) bool {
 
 // findFiles returns all SQL files in dir: schema files first (database
 // schema-create files, then table definition files), then data files matching
-// pattern. When pattern ends with ".sql", compressed variants (*.sql.gz) are
-// automatically included so compressed dumps work without requiring the user
-// to change the pattern flag.
+// pattern, then post-data object files (routines, events, triggers). When
+// pattern ends with ".sql", compressed variants (*.sql.gz) are automatically
+// included so compressed dumps work without requiring the user to change the
+// pattern flag.
 func findFiles(dir, pattern string) ([]FileLoad, error) {
 	var files []FileLoad
 	seen := make(map[string]bool)
@@ -430,6 +555,25 @@ func findFiles(dir, pattern string) ([]FileLoad, error) {
 			if !seen[p] {
 				seen[p] = true
 				files = append(files, FileLoad{Path: p, IsSchema: true})
+			}
+		}
+	}
+
+	// Object files load after all data. Collected before the data glob so the
+	// default "*.sql" pattern never picks them up as data.
+	for _, postPat := range []string{
+		"*-routines.sql", "*-routines.sql.gz",
+		"*-events.sql", "*-events.sql.gz",
+		"*-triggers.sql", "*-triggers.sql.gz",
+	} {
+		matches, err := filepath.Glob(filepath.Join(dir, postPat))
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range matches {
+			if !seen[p] {
+				seen[p] = true
+				files = append(files, FileLoad{Path: p, IsPost: true})
 			}
 		}
 	}
@@ -464,15 +608,23 @@ func findFiles(dir, pattern string) ([]FileLoad, error) {
 		}
 	}
 
-	// Load order: database creation, then table definitions, then data.
+	// Load order: database creation, table definitions, data, then routines,
+	// events, and finally triggers (which must never precede their table's data).
 	rank := func(f FileLoad) int {
+		base := filepath.Base(f.Path)
 		switch {
-		case strings.Contains(filepath.Base(f.Path), "-schema-create"):
+		case strings.Contains(base, "-schema-create"):
 			return 0
 		case f.IsSchema:
 			return 1
-		default:
+		case !f.IsPost:
 			return 2
+		case strings.Contains(base, "-routines."):
+			return 3
+		case strings.Contains(base, "-events."):
+			return 4
+		default: // triggers
+			return 5
 		}
 	}
 	sort.Slice(files, func(i, j int) bool {

--- a/internal/load/objects_test.go
+++ b/internal/load/objects_test.go
@@ -1,0 +1,197 @@
+package load
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── DELIMITER directive handling in parseStatements ─────────────────────────
+
+func TestSplitStatements_DelimiterTriggerBody(t *testing.T) {
+	input := []byte(`SET @x=1;
+DELIMITER ;;
+CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW
+BEGIN
+  SET @a = 1;
+  SET @b = 2;
+END;;
+DELIMITER ;
+SET @y=2;
+`)
+	got := splitStatements(input)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 statements, got %d: %v", len(got), got)
+	}
+	if got[0] != "SET @x=1" {
+		t.Errorf("[0] = %q", got[0])
+	}
+	if !strings.HasPrefix(got[1], "CREATE TRIGGER") || !strings.HasSuffix(got[1], "END") {
+		t.Errorf("[1] trigger body wrong: %q", got[1])
+	}
+	if !strings.Contains(got[1], "SET @a = 1;") {
+		t.Errorf("[1] lost internal semicolons: %q", got[1])
+	}
+	if got[2] != "SET @y=2" {
+		t.Errorf("[2] = %q", got[2])
+	}
+}
+
+func TestSplitStatements_DelimiterCaseInsensitive(t *testing.T) {
+	input := []byte("delimiter $$\nSELECT 1; SELECT 2$$\ndelimiter ;\nSELECT 3;")
+	got := splitStatements(input)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 statements, got %d: %v", len(got), got)
+	}
+	if got[0] != "SELECT 1; SELECT 2" {
+		t.Errorf("[0] = %q", got[0])
+	}
+	if got[1] != "SELECT 3" {
+		t.Errorf("[1] = %q", got[1])
+	}
+}
+
+func TestSplitStatements_PartialDelimiterMatchRestored(t *testing.T) {
+	// Under delimiter ";;", a lone ";" is ordinary statement text and must be
+	// restored into the statement when the second ";" never arrives.
+	input := []byte("DELIMITER ;;\nSET @a='x'; SET @b='y';;\nDELIMITER ;\n")
+	got := splitStatements(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(got), got)
+	}
+	if got[0] != "SET @a='x'; SET @b='y'" {
+		t.Errorf("[0] = %q", got[0])
+	}
+}
+
+func TestSplitStatements_DeleteIsNotADirective(t *testing.T) {
+	// "DELETE"/"DELIMITERX" share a prefix with "DELIMITER" — they must be
+	// treated as SQL, not directives.
+	input := []byte("DELETE FROM t WHERE id = 1;\nSELECT 1;")
+	got := splitStatements(input)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 statements, got %d: %v", len(got), got)
+	}
+	if got[0] != "DELETE FROM t WHERE id = 1" {
+		t.Errorf("[0] = %q", got[0])
+	}
+}
+
+func TestSplitStatements_DelimiterTokenInString(t *testing.T) {
+	// A ";;" inside a quoted string must not terminate the statement while
+	// the delimiter is ";;".
+	input := []byte("DELIMITER ;;\nSET @v = 'a;;b';;\nDELIMITER ;\n")
+	got := splitStatements(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(got), got)
+	}
+	if got[0] != "SET @v = 'a;;b'" {
+		t.Errorf("[0] = %q", got[0])
+	}
+}
+
+func TestSplitStatements_DelimiterAtEOFWithoutNewline(t *testing.T) {
+	input := []byte("DELIMITER ;;\nSELECT 1;;\nDELIMITER ;")
+	got := splitStatements(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(got), got)
+	}
+}
+
+func TestSplitStatements_GuardCommentsAroundDelimiterBlock(t *testing.T) {
+	// The exact shape go-dump writes for object files.
+	input := []byte(`USE ` + "`db`" + `;
+/*!50003 SET @saved_sql_mode = @@sql_mode */;
+/*!50003 SET sql_mode = 'STRICT_TRANS_TABLES' */;
+DELIMITER ;;
+CREATE PROCEDURE p()
+BEGIN
+  SELECT 1;
+END;;
+DELIMITER ;
+/*!50003 SET sql_mode = @saved_sql_mode */;
+`)
+	got := splitStatements(input)
+	if len(got) != 5 {
+		t.Fatalf("expected 5 statements, got %d: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[3], "CREATE PROCEDURE") || !strings.Contains(got[3], "SELECT 1;") {
+		t.Errorf("[3] = %q", got[3])
+	}
+}
+
+// ── findFiles ordering with object files ────────────────────────────────────
+
+func TestFindFiles_ObjectFileOrdering(t *testing.T) {
+	dir := t.TempDir()
+	names := []string{
+		"db.t1-triggers.sql",
+		"db.t1.sql",
+		"db-routines.sql",
+		"db-events.sql",
+		"db.t1-definition.sql",
+		"db-schema-create.sql",
+	}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("SELECT 1;"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := findFiles(dir, "*.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, f := range files {
+		got = append(got, filepath.Base(f.Path))
+	}
+	want := []string{
+		"db-schema-create.sql",
+		"db.t1-definition.sql",
+		"db.t1.sql",
+		"db-routines.sql",
+		"db-events.sql",
+		"db.t1-triggers.sql",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d files, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %s, want %s (full order: %v)", i, got[i], want[i], got)
+		}
+	}
+
+	// Object files must be flagged post (and not schema, not data).
+	for _, f := range files {
+		base := filepath.Base(f.Path)
+		isObj := strings.Contains(base, "-triggers.") || strings.Contains(base, "-routines.") || strings.Contains(base, "-events.")
+		if isObj != f.IsPost {
+			t.Errorf("%s: IsPost = %v, want %v", base, f.IsPost, isObj)
+		}
+		if isObj && f.IsSchema {
+			t.Errorf("%s: object file wrongly flagged as schema", base)
+		}
+	}
+}
+
+func TestFindFiles_CompressedObjectFiles(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"db.t1.sql.gz", "db.t1-triggers.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte{}, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, err := findFiles(dir, "*.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d: %+v", len(files), files)
+	}
+	if !strings.Contains(files[1].Path, "-triggers.sql.gz") || !files[1].IsPost {
+		t.Errorf("compressed trigger file not ordered last / flagged post: %+v", files)
+	}
+}


### PR DESCRIPTION
## Summary

go-dump can now carry triggers, stored procedures/functions, and events alongside table schemas and data, and go-load restores them in the correct order. All new flags default off — zero behavior change for existing users.

### Dump side

- New flags `--triggers`, `--routines`, `--events`, `--skip-definer` (also INI keys)
- Discovery via `information_schema`, capture via `SHOW CREATE ...` with column-name-based scanning (version-safe across 5.7/8.0/8.4/9 column layouts)
- mydumper-compatible file names: `<schema>.<table>-triggers.sql`, `<schema>-routines.sql`, `<schema>-events.sql`
- mysqldump-style `sql_mode` / `character_set_client` / `collation_connection` save-set-restore guards around every definition; per-event `time_zone` guard; bodies wrapped in `DELIMITER ;;` blocks
- `--skip-definer` strips `DEFINER=user@host` (backtick/single/double-quoted, unquoted, `CURRENT_USER[()]`) so objects restore where the definer account does not exist — the most common object-restore failure (errno 1449)
- `--add-drop-table` also emits versioned `DROP ... IF EXISTS` before each object
- Missing privileges (`SHOW_ROUTINE`, `EVENT`, `TRIGGER`) warn and skip the object; file-write errors abort the dump like schema files
- `metadata.json` records dumped counts under `"objects"`

### Load side

- `parseStatements` now understands client-side `DELIMITER` directives (case-insensitive, multi-char delimiters, partial-match restore, EOF handling) — object files load through go-load **and** the plain `mysql` client
- New serial post-data phase ordered routines → events → triggers, which runs only after every data file succeeded, so **triggers never fire during the restore**
- `--data-only` skips object files; `--skip-binlog` (replica seeding) and `--resume` cover them

### Docs

- README: flags table, object-dump example, output-files tree, restore ordering, rewritten Limitations (views still need a separate pass; object reads are not MVCC-consistent)
- Replica-seeding walkthrough step 5 now uses the native flags; mysqldump remains only for views
- `TODO-routines-triggers-events.md` tracks what shipped and the follow-ups (version-matrix coverage, views, grants)

## Test plan

- [x] Unit: definer stripping (quoted/unquoted/CURRENT_USER/embedded backticks/inside-string non-match)
- [x] Unit: DELIMITER parsing (trigger bodies, `$$`, case-insensitivity, `;;` inside strings, partial-match restore, EOF without newline, exact go-dump file shape)
- [x] Unit: `findFiles` ordering and post-phase flagging, plain and compressed
- [x] Existing dump/load suites still green; `go vet` clean
- [x] End-to-end vs MySQL 8.0.45: schema with trigger + procedure + function + DISABLED event → dump → `DROP DATABASE` → go-load restore. Verified via audit-row canary that the trigger did not fire during load; event restored still DISABLED; routines callable; trigger fires normally post-restore. Repeated with `--compress` + `--skip-definer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)