### PR TITLE
Mid-file resume for go-load: batched transactions with statement-level progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ per thread with a consistent, point-in-time snapshot using InnoDB MVCC — simil
 - [Common examples](#common-examples)
 - [Output files](#output-files)
 - [Restoring](#restoring)
+- [Resuming an interrupted dump or load](#resuming-an-interrupted-dump-or-load)
 - [Replication and GTIDs](#replication-and-gtids)
 - [Limitations](#limitations)
 - [Required privileges](#required-privileges)
@@ -158,6 +159,7 @@ go-dump --ini-file /etc/go-dump/primary.ini --databases myapp --destination /bac
 |------|---------|-------------|
 | `--dry-run` | false | Calculate chunk counts per table and print a summary. No files written. |
 | `--execute` | false | Run the dump. Mutually exclusive with `--dry-run`. |
+| `--resume` | false | Resume an interrupted dump into the same `--destination`: tables recorded as `done` in `metadata.json` are skipped, partial files from interrupted tables are removed and those tables re-dumped. `--threads` may differ from the original run. See [Resuming](#resuming-an-interrupted-dump-or-load). |
 | `--version` | false | Print version and exit. |
 | `--help` | false | Print usage and exit. |
 
@@ -523,6 +525,31 @@ Progress output (every 5 seconds):
 2026-06-10 14:02:20 INFO Progress: 521/1700 (30.6%) | Rate: 14.1 chunks/s | ETA: ~1m22s
 ```
 
+### Resume an interrupted dump
+
+A dump killed mid-run (network drop, OOM, operator Ctrl-C) restarts from
+where it left off — completed tables are never re-read:
+
+```bash
+# Original run dies partway through:
+go-dump --ini-file /etc/go-dump/prod.ini \
+  --databases myapp --destination /backups/myapp --threads 4 --execute
+
+# Same destination + --resume. Thread count can change freely.
+go-dump --ini-file /etc/go-dump/prod.ini \
+  --databases myapp --destination /backups/myapp --threads 8 --resume --execute
+```
+
+```
+INFO Resume: skipping completed table myapp.customers
+INFO Resume: removing partial file myapp.orders-thread0.sql
+INFO Resume: 12 table(s) already complete, 3 to dump this run.
+WARNING Resume: tables dumped in this run use a NEW snapshot — the combined dump is not consistent to a single point in time.
+```
+
+See [Resuming an interrupted dump or load](#resuming-an-interrupted-dump-or-load)
+for how state is tracked and the consistency caveat.
+
 ### Cloud SQL (on-prem → Cloud SQL via private IP)
 
 ```bash
@@ -551,6 +578,7 @@ A dump of `myapp.orders` with 4 threads produces:
 ├── change-replication-source.sql          # ready-to-edit replica setup script (--get-master-status)
 ├── slave-data.sql                         # replica status (--get-slave-status)
 ├── checksums.txt                          # CHECKSUM TABLE results (--checksum)
+├── load-state.json                        # written by go-load --resume (files + statements loaded)
 ├── myapp-schema-create.sql                # CREATE DATABASE IF NOT EXISTS (one per schema)
 ├── myapp.orders-definition.sql            # CREATE TABLE statement
 ├── myapp.orders-thread0.sql               # rows assigned to worker 0
@@ -644,6 +672,65 @@ ls /backups/myapp/*.sql.zst | xargs -P4 -I{} sh -c 'zstdcat {} | mysql -h target
 
 For point-in-time recovery, apply binary logs from the position recorded in
 `master-data.sql` (or `metadata.json` `binlog_file`/`binlog_position`).
+
+## Resuming an interrupted dump or load
+
+Both tools resume interrupted runs the way `mysqlsh` does with its progress
+file — and the thread/worker count may change freely between the original run
+and the resumed one.
+
+### go-dump --resume
+
+State lives in the dump's own `metadata.json` (each table is `pending`,
+`in_progress`, or `done`). On `--resume` into the same `--destination`:
+
+- tables recorded as `done` are skipped entirely;
+- partial chunk files from interrupted tables are deleted and those tables
+  re-dumped from scratch on a fresh snapshot;
+- the resumed run's `metadata.json` and `checksums.txt` still describe the
+  **whole** dump set on disk.
+
+```bash
+go-dump ... --destination /backups/myapp --threads 8 --resume --execute
+```
+
+> **Consistency caveat:** tables dumped by the resumed run use a **new**
+> snapshot, so the combined dump is not consistent to a single point in time
+> (go-dump warns at runtime). For replica seeding with GTIDs, take a fresh
+> full dump instead — the recorded GTID set only matches a single-snapshot
+> dump.
+
+### go-load --resume
+
+State lives in `<directory>/load-state.json`, written atomically after every
+completed file **and after every committed transaction batch** inside large
+data files. Data files load in explicit transactions (committed every 64&nbsp;MB
+of statements), and only committed statements are recorded — so a load killed
+mid-file resumes exactly after its last commit, never re-inserting rows the
+target already has:
+
+```bash
+# Original load dies partway through:
+go-load --host target --user root --password ... --directory /backups/myapp --workers 4 --resume
+
+# Rerun with the same command — worker count can change freely:
+go-load --host target --user root --password ... --directory /backups/myapp --workers 8 --resume
+```
+
+```
+INFO Resume: 5 file(s) already loaded
+INFO Resume: skipping schema myapp.orders-definition.sql
+INFO Resume: myapp.orders-thread1.sql — continuing after 16 committed statement(s)
+```
+
+- Pass `--resume` on the **first** run too: it costs nothing and makes the
+  state file available if the load dies.
+- `load-state.json` is keyed by file name; it applies to one dump directory
+  loaded into one target. Delete it to force a full reload, and never reuse a
+  directory's state file against a different target.
+- Transient connection drops (server gone away, lost connection) are retried
+  in-process from the last committed batch automatically, with or without
+  `--resume`.
 
 ---
 

--- a/cmd/go-load/main.go
+++ b/cmd/go-load/main.go
@@ -60,7 +60,7 @@ func main() {
 	flag.BoolVar(&setGtidPurged, "set-gtid-purged", false, "After the load, set the target's gtid_purged to the dump's captured GTID set (from metadata.json) so it can replicate with SOURCE_AUTO_POSITION=1. Refuses on active replicas or errant transactions.")
 	flag.BoolVar(&force, "force", false, "With --set-gtid-purged: allow acting on a stopped replication channel, and allow RESET MASTER / RESET BINARY LOGS AND GTIDS when the target's gtid_executed is non-empty (destroys the target's binlog history).")
 	flag.BoolVar(&verify, "verify", false, "Verify checksums after loading (requires checksums.txt in --directory)")
-	flag.BoolVar(&resume, "resume", false, "Resume a previous load: skip files recorded in load-state.json")
+	flag.BoolVar(&resume, "resume", false, "Resume a previous load: skip files recorded in load-state.json and continue partially-loaded data files after their last committed statement. --workers may differ between runs.")
 	flag.BoolVar(&quiet, "quiet", false, "Suppress INFO messages")
 	flag.BoolVar(&debug, "debug", false, "Print debug information")
 	flag.StringVar(&iniFile, "ini-file", "", "INI configuration file (supports [client] and [go-load] sections)")

--- a/internal/load/importer.go
+++ b/internal/load/importer.go
@@ -141,7 +141,7 @@ func (imp *Importer) ImportDirectory(ctx context.Context, dir, pattern string, l
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			if err := imp.loadFile(ctx, fl.Path); err != nil {
+			if err := imp.loadDataFile(ctx, fl.Path, ls); err != nil {
 				errsCh <- fmt.Errorf("%s: %w", fname, err)
 				return
 			}
@@ -200,9 +200,18 @@ func (imp *Importer) ImportFile(ctx context.Context, path string) error {
 
 const maxRetries = 3
 
+// txBatchBytes is the transaction size for data files: statements are applied
+// inside explicit transactions committed once this many statement bytes have
+// accumulated. Commits are the durability points for mid-file resume — only
+// committed statements are recorded in load-state.json, so a crash or retry
+// never re-applies rows the target already has.
+const txBatchBytes = 64 * 1024 * 1024
+
 // loadFile opens path (plain, .gz, or .zst), acquires a dedicated connection,
 // sets session variables, and streams SQL statements one at a time.
 // Retries up to maxRetries times on transient MySQL connection errors.
+// Used for schema and post-data (routine/event/trigger) files, whose DDL
+// statements commit implicitly and cannot be batched.
 func (imp *Importer) loadFile(ctx context.Context, path string) error {
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
@@ -224,8 +233,63 @@ func (imp *Importer) loadFile(ctx context.Context, path string) error {
 	return fmt.Errorf("after %d attempts: %w", maxRetries, lastErr)
 }
 
+// loadDataFile loads a data file inside batched transactions with
+// statement-level progress, so an interrupted or retried load never
+// re-applies committed rows. Progress is kept in memory for transparent
+// retries and, when ls is non-nil, persisted to load-state.json so a later
+// --resume run continues mid-file (like mysqlsh's load progress file).
+func (imp *Importer) loadDataFile(ctx context.Context, path string, ls *LoadState) error {
+	name := filepath.Base(path)
+	applied := int64(0)
+	if ls != nil {
+		applied = ls.Progress(name)
+		if applied > 0 {
+			log.Infof("Resume: %s — continuing after %d committed statement(s)", name, applied)
+		}
+	}
+	progress := func(total int64) error {
+		applied = total
+		if ls != nil {
+			if err := ls.SetProgress(name, total); err != nil {
+				return fmt.Errorf("record progress for %s: %w", name, err)
+			}
+		}
+		return nil
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(attempt*attempt) * time.Second
+			log.Warningf("Retry %d/%d for %s (waiting %s, resuming after %d statements): %v",
+				attempt, maxRetries-1, name, delay, applied, lastErr)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		lastErr = imp.withFileConn(ctx, path, func(conn *sql.Conn, r io.Reader) error {
+			return execBatched(ctx, conn, r, applied, progress)
+		})
+		if lastErr == nil || !isRetryable(lastErr) {
+			return lastErr
+		}
+	}
+	return fmt.Errorf("after %d attempts: %w", maxRetries, lastErr)
+}
+
 // doLoadFile performs a single attempt at loading path.
 func (imp *Importer) doLoadFile(ctx context.Context, path string) error {
+	return imp.withFileConn(ctx, path, func(conn *sql.Conn, r io.Reader) error {
+		return execStream(ctx, conn, r)
+	})
+}
+
+// withFileConn opens path (plain, .gz, or .zst), acquires a dedicated
+// connection with the load session variables set, and hands the decompressed
+// statement stream to fn.
+func (imp *Importer) withFileConn(ctx context.Context, path string, fn func(*sql.Conn, io.Reader) error) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -281,7 +345,7 @@ func (imp *Importer) doLoadFile(ctx context.Context, path string) error {
 		}
 	}
 
-	return execStream(ctx, conn, bufio.NewReaderSize(underlying, 4*1024*1024))
+	return fn(conn, bufio.NewReaderSize(underlying, 4*1024*1024))
 }
 
 // execStream reads from r and executes each SQL statement as it is found.
@@ -293,6 +357,87 @@ func execStream(ctx context.Context, conn *sql.Conn, r io.Reader) error {
 		}
 		return nil
 	})
+}
+
+// execBatched streams statements from r into conn inside explicit
+// transactions, skipping the first skip statements (already committed by a
+// previous attempt) and reporting each commit through progress.
+func execBatched(ctx context.Context, conn *sql.Conn, r io.Reader, skip int64, progress func(int64) error) error {
+	return batchStream(r, skip, txBatchBytes, func(stmt string) error {
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("exec %q: %w", truncate(stmt, 120), err)
+		}
+		return nil
+	}, progress)
+}
+
+// batchStream drives a resumable, transactional statement stream through
+// exec. Statements are wrapped in BEGIN/COMMIT batches of roughly batchBytes
+// statement bytes; progress is called with the cumulative statement count
+// after every successful COMMIT — and never before it, so the recorded count
+// only ever covers durable rows.
+//
+// The first skip statements are not re-executed, with one exception: USE
+// statements are session state, not data — go-dump writes unqualified
+// INSERTs that rely on the USE line before them, so a resumed stream must
+// replay USE to land the remaining statements in the right schema.
+func batchStream(r io.Reader, skip int64, batchBytes uint64, exec func(string) error, progress func(int64) error) error {
+	var seen int64
+	var inTx bool
+	var txBytes uint64
+
+	err := parseStatements(r, func(stmt string) error {
+		seen++
+		if seen <= skip {
+			if isUseStatement(stmt) {
+				return exec(stmt)
+			}
+			return nil
+		}
+		if !inTx {
+			if err := exec("BEGIN"); err != nil {
+				return err
+			}
+			inTx = true
+			txBytes = 0
+		}
+		if err := exec(stmt); err != nil {
+			return err
+		}
+		txBytes += uint64(len(stmt))
+		if txBytes >= batchBytes {
+			if err := exec("COMMIT"); err != nil {
+				return err
+			}
+			inTx = false
+			return progress(seen)
+		}
+		return nil
+	})
+	if err != nil {
+		// The connection's open transaction (if any) rolls back when the
+		// caller closes it — nothing uncommitted survives to be double-loaded.
+		return err
+	}
+	if inTx {
+		if err := exec("COMMIT"); err != nil {
+			return err
+		}
+		return progress(seen)
+	}
+	return nil
+}
+
+// isUseStatement reports whether stmt is a USE statement ("USE `db`" or
+// "USE db", any case). Statements arrive trimmed from parseStatements.
+func isUseStatement(stmt string) bool {
+	if len(stmt) < 4 {
+		return false
+	}
+	if upperByte(stmt[0]) != 'U' || upperByte(stmt[1]) != 'S' || upperByte(stmt[2]) != 'E' {
+		return false
+	}
+	return stmt[3] == ' ' || stmt[3] == '\t' || stmt[3] == '`'
 }
 
 // parseStatements reads SQL from r and calls cb for each complete statement.

--- a/internal/load/importer_test.go
+++ b/internal/load/importer_test.go
@@ -1,8 +1,11 @@
 package load
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -376,5 +379,137 @@ func touch(t *testing.T, dir, name string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte{}, 0644); err != nil {
 		t.Fatalf("touch %s: %v", name, err)
+	}
+}
+
+// --- batchStream / mid-file resume ---
+
+// runBatchStream feeds sql through batchStream and returns every statement
+// handed to exec (including BEGIN/COMMIT) plus each progress value reported.
+func runBatchStream(t *testing.T, sql string, skip int64, batchBytes uint64) (execed []string, commits []int64) {
+	t.Helper()
+	err := batchStream(strings.NewReader(sql), skip, batchBytes,
+		func(stmt string) error {
+			execed = append(execed, stmt)
+			return nil
+		},
+		func(n int64) error {
+			commits = append(commits, n)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("batchStream: %v", err)
+	}
+	return execed, commits
+}
+
+func TestBatchStream_WrapsInTransaction(t *testing.T) {
+	execed, commits := runBatchStream(t,
+		"INSERT INTO `t` VALUES (1);\nINSERT INTO `t` VALUES (2);", 0, 1<<20)
+
+	want := []string{"BEGIN", "INSERT INTO `t` VALUES (1)", "INSERT INTO `t` VALUES (2)", "COMMIT"}
+	if !reflect.DeepEqual(execed, want) {
+		t.Errorf("execed = %v, want %v", execed, want)
+	}
+	if !reflect.DeepEqual(commits, []int64{2}) {
+		t.Errorf("commits = %v, want [2]", commits)
+	}
+}
+
+func TestBatchStream_CommitsOnBatchBytes(t *testing.T) {
+	// batchBytes of 1 forces a commit after every statement.
+	execed, commits := runBatchStream(t,
+		"INSERT INTO `t` VALUES (1);\nINSERT INTO `t` VALUES (2);\nINSERT INTO `t` VALUES (3);", 0, 1)
+
+	want := []string{
+		"BEGIN", "INSERT INTO `t` VALUES (1)", "COMMIT",
+		"BEGIN", "INSERT INTO `t` VALUES (2)", "COMMIT",
+		"BEGIN", "INSERT INTO `t` VALUES (3)", "COMMIT",
+	}
+	if !reflect.DeepEqual(execed, want) {
+		t.Errorf("execed = %v, want %v", execed, want)
+	}
+	if !reflect.DeepEqual(commits, []int64{1, 2, 3}) {
+		t.Errorf("commits = %v, want [1 2 3]", commits)
+	}
+}
+
+func TestBatchStream_SkipReplaysOnlyUse(t *testing.T) {
+	sql := "USE `mydb`;\n" +
+		"INSERT INTO `t` VALUES (1);\n" +
+		"INSERT INTO `t` VALUES (2);\n" +
+		"INSERT INTO `t` VALUES (3);"
+
+	// Resume after 2 committed statements (the USE and the first INSERT):
+	// the USE must be replayed for session state, the INSERT must not.
+	execed, commits := runBatchStream(t, sql, 2, 1<<20)
+
+	want := []string{
+		"USE `mydb`",
+		"BEGIN", "INSERT INTO `t` VALUES (2)", "INSERT INTO `t` VALUES (3)", "COMMIT",
+	}
+	if !reflect.DeepEqual(execed, want) {
+		t.Errorf("execed = %v, want %v", execed, want)
+	}
+	// Progress counts are cumulative over the whole file, including skipped.
+	if !reflect.DeepEqual(commits, []int64{4}) {
+		t.Errorf("commits = %v, want [4]", commits)
+	}
+}
+
+func TestBatchStream_FullySkippedFile(t *testing.T) {
+	sql := "USE `mydb`;\nINSERT INTO `t` VALUES (1);"
+	execed, commits := runBatchStream(t, sql, 2, 1<<20)
+
+	// Only the USE replays; nothing new to commit, so no progress calls.
+	if !reflect.DeepEqual(execed, []string{"USE `mydb`"}) {
+		t.Errorf("execed = %v, want only the USE", execed)
+	}
+	if len(commits) != 0 {
+		t.Errorf("commits = %v, want none", commits)
+	}
+}
+
+func TestBatchStream_ExecErrorStopsBeforeProgress(t *testing.T) {
+	sql := "INSERT INTO `t` VALUES (1);\nINSERT INTO `t` VALUES (2);"
+	boom := errors.New("boom")
+	var commits []int64
+	err := batchStream(strings.NewReader(sql), 0, 1<<20,
+		func(stmt string) error {
+			if strings.Contains(stmt, "(2)") {
+				return boom
+			}
+			return nil
+		},
+		func(n int64) error {
+			commits = append(commits, n)
+			return nil
+		})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+	if len(commits) != 0 {
+		t.Errorf("progress reported %v despite no COMMIT", commits)
+	}
+}
+
+func TestIsUseStatement(t *testing.T) {
+	cases := []struct {
+		stmt string
+		want bool
+	}{
+		{"USE `mydb`", true},
+		{"use mydb", true},
+		{"Use\tmydb", true},
+		{"USE`mydb`", true},
+		{"USER SELECT", false},
+		{"INSERT INTO `use` VALUES (1)", false},
+		{"USE", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isUseStatement(c.stmt); got != c.want {
+			t.Errorf("isUseStatement(%q) = %v, want %v", c.stmt, got, c.want)
+		}
 	}
 }

--- a/internal/load/loadstate.go
+++ b/internal/load/loadstate.go
@@ -9,9 +9,13 @@ import (
 
 // LoadState persists which files have been successfully loaded, enabling --resume.
 // Written atomically to <directory>/load-state.json after each successful file load.
+// FileProgress tracks partially-loaded data files by the number of statements
+// committed so far, so an interrupted load resumes mid-file instead of
+// replaying rows that are already in the target.
 type LoadState struct {
-	StartTime      time.Time `json:"start_time"`
-	CompletedFiles []string  `json:"completed_files"`
+	StartTime      time.Time        `json:"start_time"`
+	CompletedFiles []string         `json:"completed_files"`
+	FileProgress   map[string]int64 `json:"file_progress,omitempty"`
 
 	mu    sync.Mutex
 	path  string
@@ -22,8 +26,9 @@ type LoadState struct {
 func NewLoadState(dir string) (*LoadState, error) {
 	path := dir + "/load-state.json"
 	ls := &LoadState{
-		path:  path,
-		index: make(map[string]bool),
+		path:         path,
+		index:        make(map[string]bool),
+		FileProgress: make(map[string]int64),
 	}
 
 	data, err := os.ReadFile(path)
@@ -36,6 +41,9 @@ func NewLoadState(dir string) (*LoadState, error) {
 	}
 	if err := json.Unmarshal(data, ls); err != nil {
 		return nil, err
+	}
+	if ls.FileProgress == nil {
+		ls.FileProgress = make(map[string]int64)
 	}
 	for _, f := range ls.CompletedFiles {
 		ls.index[f] = true
@@ -57,7 +65,26 @@ func (ls *LoadState) Len() int {
 	return len(ls.CompletedFiles)
 }
 
+// Progress returns the number of statements already committed for a
+// partially-loaded file, or 0 when the file has not been started.
+func (ls *LoadState) Progress(name string) int64 {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	return ls.FileProgress[name]
+}
+
+// SetProgress records that n statements of name have been committed and
+// flushes the state file atomically.
+func (ls *LoadState) SetProgress(name string, n int64) error {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	ls.FileProgress[name] = n
+	return ls.write()
+}
+
 // Mark records name as complete and flushes the state file atomically.
+// Any partial progress entry for name is dropped — completed files are
+// tracked by CompletedFiles alone.
 func (ls *LoadState) Mark(name string) error {
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
@@ -66,6 +93,7 @@ func (ls *LoadState) Mark(name string) error {
 	}
 	ls.index[name] = true
 	ls.CompletedFiles = append(ls.CompletedFiles, name)
+	delete(ls.FileProgress, name)
 	return ls.write()
 }
 

--- a/internal/load/loadstate_test.go
+++ b/internal/load/loadstate_test.go
@@ -103,6 +103,77 @@ func TestLoadState_Len(t *testing.T) {
 	}
 }
 
+func TestProgress_SetGetPersist(t *testing.T) {
+	dir := t.TempDir()
+	ls, _ := NewLoadState(dir)
+
+	if got := ls.Progress("a.sql"); got != 0 {
+		t.Errorf("Progress before Set = %d, want 0", got)
+	}
+	if err := ls.SetProgress("a.sql", 42); err != nil {
+		t.Fatalf("SetProgress: %v", err)
+	}
+	if got := ls.Progress("a.sql"); got != 42 {
+		t.Errorf("Progress = %d, want 42", got)
+	}
+
+	// A new state loaded from disk must see the partial progress.
+	ls2, err := NewLoadState(dir)
+	if err != nil {
+		t.Fatalf("NewLoadState (resume): %v", err)
+	}
+	if got := ls2.Progress("a.sql"); got != 42 {
+		t.Errorf("Progress after reload = %d, want 42", got)
+	}
+}
+
+func TestMark_ClearsProgress(t *testing.T) {
+	dir := t.TempDir()
+	ls, _ := NewLoadState(dir)
+
+	_ = ls.SetProgress("a.sql", 10)
+	if err := ls.Mark("a.sql"); err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	if got := ls.Progress("a.sql"); got != 0 {
+		t.Errorf("Progress after Mark = %d, want 0", got)
+	}
+
+	ls2, err := NewLoadState(dir)
+	if err != nil {
+		t.Fatalf("NewLoadState (resume): %v", err)
+	}
+	if !ls2.HasFile("a.sql") {
+		t.Error("a.sql should be complete after reload")
+	}
+	if got := ls2.Progress("a.sql"); got != 0 {
+		t.Errorf("Progress after reload = %d, want 0", got)
+	}
+}
+
+func TestNewLoadState_OldFormatWithoutProgress(t *testing.T) {
+	// load-state.json written by a previous go-load version has no
+	// file_progress key — it must still load, with zero progress everywhere.
+	dir := t.TempDir()
+	old := `{"start_time":"2026-01-01T00:00:00Z","completed_files":["a.sql"]}`
+	if err := os.WriteFile(filepath.Join(dir, "load-state.json"), []byte(old), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ls, err := NewLoadState(dir)
+	if err != nil {
+		t.Fatalf("NewLoadState: %v", err)
+	}
+	if !ls.HasFile("a.sql") {
+		t.Error("a.sql should be complete")
+	}
+	if got := ls.Progress("b.sql"); got != 0 {
+		t.Errorf("Progress = %d, want 0", got)
+	}
+	if err := ls.SetProgress("b.sql", 3); err != nil {
+		t.Fatalf("SetProgress on old-format state: %v", err)
+	}
+}
+
 func TestNewLoadState_CorruptFile(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "load-state.json"), []byte("not-json"), 0644); err != nil {


### PR DESCRIPTION
## Summary

`--resume` existed on both tools but had one correctness gap on the load side: a data file interrupted **mid-load** replayed from statement 1 with autocommit, re-inserting rows the target already had (duplicate-key failures, or silent duplicates on PK-less tables). The in-process transient-error retry path had the same flaw.

- Data files now load inside explicit transactions committed every 64 MB of statements (`internal/load/importer.go`).
- The committed-statement count is persisted to `load-state.json` (`file_progress`) only **after** each COMMIT, so an interrupted or retried load continues exactly at its last durable point — same model as mysqlsh's load progress file.
- `USE` statements are re-executed during the skip phase, since chunk-file INSERTs are schema-unqualified.
- `--threads` / `--workers` may change freely between the original and resumed runs on both tools.
- README: new "Resuming an interrupted dump or load" section, `--resume` flag rows, examples, and the consistency caveat (a resumed dump mixes snapshots — not suitable for GTID replica seeding).

## Verification

End-to-end against MySQL 8.0.46 (the repo's docker matrix container) with a 378 MB / 400k-row database:

- **Dump resume**: killed mid-`big`-table, resumed with `--threads` 2→4 — done tables skipped, partial files cleaned, `metadata.json` status `complete`.
- **Load resume**: SIGKILLed mid-file after one 64 MB batch (16 statements recorded in `file_progress`), resumed with `--workers` 2→4 — exact row counts (400000/3/3), zero duplicate ids, progress entry cleared on completion.
- 9 new unit tests (batching, skip/USE replay, progress-only-after-commit, old-format state files); `go test ./internal/load/` passes. Note: `make test-unit` fails on `main` today because the dump package's `init()` opens a live MySQL connection — pre-existing, untouched here.

## Known limitation (shared with mysqlsh)

A crash in the window between a COMMIT and the progress-file write replays one batch on resume. On tables with a PK/unique key this fails loudly with duplicate-key errors rather than silently duplicating rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)