### PR TITLE
Replication setup from the dump: --show-replication (manual) and --start-replication (automatic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ Written at dump start (`status: in_progress`) and updated on clean finish
   "end_time": "2026-06-10T14:05:30Z",
   "status": "complete",
   "mysql_host": "db01.example.com",
+  "mysql_port": 3306,
   "mysql_version": "8.0.43",
   "binlog_file": "binlog.000042",
   "binlog_position": 1421,
@@ -745,7 +746,7 @@ Two distinct workflows:
 
 | Goal | How |
 |------|-----|
-| Seed a new replica and start replication | Dump **with** `--get-master-status`, restore with `--skip-binlog --set-gtid-purged`, run the generated `change-replication-source.sql` |
+| Seed a new replica and start replication | Dump **with** `--get-master-status`, restore with `--skip-binlog --set-gtid-purged`, then run the SQL printed by `go-load --show-replication` (or edit the generated `change-replication-source.sql`) |
 | Repopulate tables/databases without touching replication | Dump **without** `--get-master-status` (the default) and just restore |
 
 A complete real-world transcript of re-seeding a live replica — including the
@@ -928,8 +929,49 @@ CHANGE REPLICATION SOURCE TO
 > - `SET GLOBAL gtid_purged` requires `SUPER` / `SYSTEM_VARIABLES_ADMIN`, which
 >   managed services (Cloud SQL, RDS) do not grant — use the provider's external
 >   replication API there instead.
-> - These post-restore steps are manual today. Automating them in go-load is
->   planned — see [docs/GTID-REPLICATION.md](docs/GTID-REPLICATION.md).
+> - The replication setup itself stays a manual, reviewed step by design —
+>   `go-load --show-replication` (below) prints the exact statements with the
+>   dump's recorded coordinates filled in; you run them when you're ready.
+>   See also [docs/GTID-REPLICATION.md](docs/GTID-REPLICATION.md).
+
+### Printing the replication statements (`--show-replication`)
+
+`go-load --show-replication` parses the dump's `metadata.json` (plain JSON —
+no scraping of SQL comments) and prints ready-to-run setup SQL for **both**
+modes: GTID `SOURCE_AUTO_POSITION = 1` and binlog file/position. It connects
+to nothing and executes nothing — review the output, then run it manually or
+pipe it into the mysql client:
+
+```bash
+# Placeholders for user/password unless provided:
+go-load --directory /backups/myapp --show-replication
+
+# Fully filled in and runnable as-is. --source-host/--source-port override the
+# recorded values when the replica reaches the source by another address
+# (metadata records the host/port the DUMP used, e.g. 127.0.0.1 via a tunnel):
+go-load --directory /backups/myapp --show-replication \
+  --source-host primary1.db.internal --source-port 3306 \
+  --repl-user repl --repl-password 'secret'   # or GOLOAD_REPL_PASSWORD env
+
+# Manual-but-piped:
+go-load --directory /backups/myapp --show-replication ... | mysql -h replica1 -u root -p
+```
+
+When the dump has a GTID set, the AUTO_POSITION block is runnable and the
+file/position block is a commented alternative (plus a commented MySQL 5.7
+`CHANGE MASTER` variant). The `SET GLOBAL gtid_purged` line is printed
+commented — prefer `go-load --set-gtid-purged`, which applies it with errant-
+transaction and running-channel safety gates.
+
+**How the coordinates are captured** (dump side, `--get-master-status`): the
+classic mysqldump pattern — take the lock (`FLUSH TABLES WITH READ LOCK`, or
+`LOCK TABLES ... READ` when the dumped set is InnoDB-only), open every
+worker's `START TRANSACTION WITH CONSISTENT SNAPSHOT`, run
+`SHOW MASTER STATUS` (8.4+: `SHOW BINARY LOG STATUS`) — one statement that
+returns binlog file, position, **and** `Executed_Gtid_Set` atomically — then
+`UNLOCK TABLES` immediately. The lock window is milliseconds and bounded by
+`--lock-wait-timeout`, and the coordinates are guaranteed to match the worker
+snapshots because both are pinned under the same lock.
 
 ### Dumping without GTIDs (repopulating tables, replication-safe)
 

--- a/README.md
+++ b/README.md
@@ -655,6 +655,62 @@ never fire while the data is being loaded. go-load understands the
 go-load --host target-host --user root --password ... --directory /backups/myapp --workers 4 --verify
 ```
 
+### go-load flags
+
+Connection:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | localhost | Target MySQL host. |
+| `--port` | 3306 | Target MySQL port. |
+| `--user` | root | Target MySQL user. |
+| `--password` | — | Target MySQL password (or set `GOLOAD_PASSWORD` — keeps it out of shell history). |
+| `--socket` | — | Unix socket path (overrides `--host`/`--port`). |
+| `--database` | — | Run `USE <db>` on every connection instead of relying on `USE` statements in the files (pairs with dumps taken with `--skip-use-database`). |
+| `--ini-file` | — | INI file with connection settings (`[client]` and `[go-load]` sections). Flags win over INI values. |
+
+What to load:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--directory` | — | Directory of dump files. Loads in dependency order: schema-create → table definitions → data (parallel) → routines → events → triggers. |
+| `--file` | — | Load a single SQL file instead of a directory. |
+| `--pattern` | `*.sql` | Glob for data files in `--directory`. The default also picks up `*.sql.gz` / `*.sql.zst` automatically. |
+| `--data-only` | false | Skip schema and post-data (trigger/routine/event) files; load data files only. |
+
+Execution and safety:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--workers` | 4 | Parallel workers for data files. May change freely between resumed runs. |
+| `--resume` | false | Skip files recorded in `load-state.json` and continue partially-loaded data files after their last committed statement. Cheap on the first run — pass it always. |
+| `--verify` | false | After loading, compare `CHECKSUM TABLE` on the target against the dump's `checksums.txt`. |
+| `--skip-binlog` | false | `SET SQL_LOG_BIN=0` on every load connection: the restore is invisible to the target's binlog, downstream replicas, and `gtid_executed`. Requires `SUPER`/`SYSTEM_VARIABLES_ADMIN` (not granted on Cloud SQL/RDS). |
+| `--force` | false | Allow acting on a configured-but-**stopped** replication channel, and (with `--set-gtid-purged`) allow the destructive `RESET MASTER` / `RESET BINARY LOGS AND GTIDS` when `gtid_executed` is a non-empty subset of the dump's set. Never overrides the errant-transaction or running-channel gates. |
+
+Replication (details in [Replication and GTIDs](#replication-and-gtids)):
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--set-gtid-purged` | false | After the load, seed the target's `gtid_purged` from the dump's GTID set so it can use `SOURCE_AUTO_POSITION=1`. Guarded: refuses running channels, errant transactions, and non-empty GTID state without `--force`. |
+| `--show-replication` | false | Print ready-to-run replication SQL parsed from `metadata.json`, then exit. Read-only — connects to nothing; stdout is pipeable into `mysql`. |
+| `--start-replication` | false | After the load, run `CHANGE REPLICATION SOURCE` + `START REPLICA` on the target and wait (≤15s) for both threads to come up; thread errors (bad credentials, missing binlogs) are hard errors. Requires `--repl-user`. |
+| `--replication-mode` | auto | `auto` (GTID auto-position when the dump has a GTID set and the target has `gtid_mode=ON`, else file/position), `gtid`, or `file-pos`. |
+| `--source-host` | metadata | Source host for replication (default `mysql_host` from `metadata.json` — override when the replica reaches the source by a different address than the dump used). |
+| `--source-port` | metadata | Source port (default `mysql_port` from `metadata.json`, else 3306). |
+| `--repl-user` | — | Replication account on the source (needs `REPLICATION SLAVE`). |
+| `--repl-password` | — | Replication password (or `GOLOAD_REPL_PASSWORD`). Redacted from all logged statements. |
+| `--source-ssl` | false | Add `SOURCE_SSL=1` — encrypt the replication connection. |
+| `--get-source-public-key` | false | Add `GET_SOURCE_PUBLIC_KEY=1` — required when the replication user authenticates with `caching_sha2_password` (the 8.0+ default) over a non-TLS connection. Omitted automatically on pre-8.0.4 targets. |
+
+Logging:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--quiet` | false | Suppress INFO messages. |
+| `--debug` | false | Debug-level logging. |
+| `--version` | false | Print version and exit. |
+
 With standard MySQL tooling instead:
 
 ```bash
@@ -783,22 +839,28 @@ script with the captured coordinates already filled in (GTID auto-position,
 5.7 syntax, and file/position variants). go-load never executes it; it is for
 you.
 
-Restore onto the new replica, then configure replication:
+Restore onto the new replica and start replication — **one command**:
 
 ```bash
-# 1. Load the data and hand over the GTID state in one step:
-#    --skip-binlog     keeps the load out of the replica's own GTID history
-#    --set-gtid-purged sets gtid_purged to the dump's snapshot GTID set
-#                      (from metadata.json), with safety checks — it refuses
-#                      on running replicas and on errant transactions.
+#  --skip-binlog        keeps the load out of the replica's own GTID history
+#  --set-gtid-purged    sets gtid_purged to the dump's snapshot GTID set
+#                       (from metadata.json), with safety checks — it refuses
+#                       on running replicas and on errant transactions
+#  --start-replication  CHANGE REPLICATION SOURCE + START REPLICA, then waits
+#                       for both threads to come up healthy
 go-load --host replica1 --user root --password ... \
-  --directory /backups/seed --workers 8 --verify \
-  --skip-binlog --set-gtid-purged
+  --directory /backups/seed --workers 8 --resume --verify \
+  --skip-binlog --set-gtid-purged \
+  --start-replication --source-host primary1.db.internal \
+  --repl-user repl --repl-password 'secret'
 ```
 
+Prefer to run the final step yourself? Drop `--start-replication` and either
+run the SQL printed by `go-load --show-replication` (coordinates parsed from
+`metadata.json`, pipeable into `mysql`) or edit the dump's
+`change-replication-source.sql` template by hand:
+
 ```sql
--- 2. Point the replica at the primary: edit SOURCE_USER / SOURCE_PASSWORD in
---    the dump's change-replication-source.sql and run it, or by hand:
 CHANGE REPLICATION SOURCE TO
   SOURCE_HOST = 'primary1.db.internal',
   SOURCE_PORT = 3306,
@@ -807,7 +869,6 @@ CHANGE REPLICATION SOURCE TO
   SOURCE_AUTO_POSITION = 1;         -- MySQL 8.0.23+; use CHANGE MASTER TO / MASTER_AUTO_POSITION=1 on 5.7
 START REPLICA;                      -- START SLAVE on 5.7
 
--- 3. Verify
 SHOW REPLICA STATUS\G               -- Replica_IO_Running / Replica_SQL_Running: Yes
 ```
 

--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ Two distinct workflows:
 
 | Goal | How |
 |------|-----|
-| Seed a new replica and start replication | Dump **with** `--get-master-status`, restore with `--skip-binlog --set-gtid-purged`, then run the SQL printed by `go-load --show-replication` (or edit the generated `change-replication-source.sql`) |
+| Seed a new replica and start replication | Dump **with** `--get-master-status`, then one command: `go-load --skip-binlog --set-gtid-purged --start-replication` — or keep the last step manual with `go-load --show-replication` |
 | Repopulate tables/databases without touching replication | Dump **without** `--get-master-status` (the default) and just restore |
 
 A complete real-world transcript of re-seeding a live replica — including the
@@ -962,6 +962,47 @@ file/position block is a commented alternative (plus a commented MySQL 5.7
 `CHANGE MASTER` variant). The `SET GLOBAL gtid_purged` line is printed
 commented — prefer `go-load --set-gtid-purged`, which applies it with errant-
 transaction and running-channel safety gates.
+
+### Starting replication automatically (`--start-replication`)
+
+`go-load --start-replication` runs the `CHANGE REPLICATION SOURCE` /
+`START REPLICA` itself (version-aware: `CHANGE MASTER TO` / `START SLAVE` on
+5.7 and pre-8.0.23 targets), then polls replica status until both threads
+report running — surfacing `Last_IO_Error` / `Last_SQL_Error` (bad
+credentials, missing binlogs, apply failures) as a hard error instead of
+exiting green. The password is never logged. Combined with the load, seeding
+a replica is one command:
+
+```bash
+go-load --host replica1 --user root --password ... \
+  --directory /backups/myapp --workers 8 --resume \
+  --skip-binlog --set-gtid-purged \
+  --start-replication --source-host primary1.db.internal \
+  --repl-user repl --repl-password 'secret'      # or GOLOAD_REPL_PASSWORD
+```
+
+```
+INFO Replication mode: gtid
+INFO Executing: CHANGE REPLICATION SOURCE TO SOURCE_HOST = 'primary1.db.internal', ..., SOURCE_PASSWORD = '<redacted>', SOURCE_AUTO_POSITION = 1
+INFO Executing: START REPLICA
+INFO Replication running: IO=Yes SQL=Yes, seconds behind source: 0
+```
+
+- `--replication-mode` picks the coordinates: `auto` (default) uses GTID
+  auto-position when the dump has a GTID set and the target has
+  `gtid_mode=ON`, else binlog file/position; `gtid` and `file-pos` force one
+  and fail loudly if its prerequisites are missing.
+- Safety gates match `--set-gtid-purged`: a **running** channel always
+  aborts; a configured-but-stopped channel requires `--force`; in GTID mode
+  the target's `gtid_executed` must exactly equal the dump's set (anything
+  less would re-fetch rows the load already inserted, anything more is
+  errant) — pair with `--set-gtid-purged`, which establishes exactly that.
+- `--source-ssl` adds `SOURCE_SSL=1`; `--get-source-public-key` adds
+  `GET_SOURCE_PUBLIC_KEY=1`, needed when the replication user authenticates
+  with `caching_sha2_password` (the 8.0+ default) over a non-TLS connection.
+- To re-run just this step after a load (e.g. after fixing credentials):
+  re-run the same command — `--resume` makes the load a no-op — after
+  `STOP REPLICA; RESET REPLICA ALL` on the target if a channel was configured.
 
 **How the coordinates are captured** (dump side, `--get-master-status`): the
 classic mysqldump pattern — take the lock (`FLUSH TABLES WITH READ LOCK`, or

--- a/cmd/go-load/main.go
+++ b/cmd/go-load/main.go
@@ -39,6 +39,11 @@ func main() {
 		force         bool
 		verify        bool
 		resume        bool
+		showRepl      bool
+		sourceHost    string
+		sourcePort    int
+		replUser      string
+		replPassword  string
 		quiet         bool
 		debug         bool
 		iniFile       string
@@ -61,6 +66,11 @@ func main() {
 	flag.BoolVar(&force, "force", false, "With --set-gtid-purged: allow acting on a stopped replication channel, and allow RESET MASTER / RESET BINARY LOGS AND GTIDS when the target's gtid_executed is non-empty (destroys the target's binlog history).")
 	flag.BoolVar(&verify, "verify", false, "Verify checksums after loading (requires checksums.txt in --directory)")
 	flag.BoolVar(&resume, "resume", false, "Resume a previous load: skip files recorded in load-state.json and continue partially-loaded data files after their last committed statement. --workers may differ between runs.")
+	flag.BoolVar(&showRepl, "show-replication", false, "Print ready-to-run replication setup SQL (GTID AUTO_POSITION and binlog file/position) parsed from the dump's metadata.json in --directory, then exit. Connects to nothing and executes nothing.")
+	flag.StringVar(&sourceHost, "source-host", "", "With --show-replication: source host for the statements (default: mysql_host from metadata.json — override when the replica reaches the source by another address)")
+	flag.IntVar(&sourcePort, "source-port", 0, "With --show-replication: source port (default: mysql_port from metadata.json, else 3306)")
+	flag.StringVar(&replUser, "repl-user", "", "With --show-replication: replication user for the statements (default: <repl_user> placeholder)")
+	flag.StringVar(&replPassword, "repl-password", "", "With --show-replication: replication password (or set GOLOAD_REPL_PASSWORD env var; default: <repl_password> placeholder)")
 	flag.BoolVar(&quiet, "quiet", false, "Suppress INFO messages")
 	flag.BoolVar(&debug, "debug", false, "Print debug information")
 	flag.StringVar(&iniFile, "ini-file", "", "INI configuration file (supports [client] and [go-load] sections)")
@@ -100,6 +110,48 @@ func main() {
 	}
 	if setGtidPurged && directory == "" {
 		log.Fatal("--set-gtid-purged requires --directory (the GTID set comes from the dump's metadata.json).")
+	}
+
+	// --show-replication: parse metadata.json, print the setup SQL, exit.
+	// Read-only — no MySQL connection, no load. Output goes to stdout so it
+	// can be reviewed, redirected, or piped into the mysql client.
+	if showRepl {
+		if directory == "" {
+			log.Fatal("--show-replication requires --directory (coordinates come from the dump's metadata.json).")
+		}
+		meta, err := dump.LoadDumpMetadata(directory)
+		if err != nil {
+			log.Fatalf("--show-replication: cannot read metadata.json: %v", err)
+		}
+		if meta.Status != "complete" {
+			log.Warningf("Dump status is %q, not \"complete\" — its coordinates may not describe a restorable dump.", meta.Status)
+		}
+		if replPassword == "" {
+			if env := os.Getenv("GOLOAD_REPL_PASSWORD"); env != "" {
+				replPassword = env
+			}
+		}
+		info := load.ReplicationInfo{
+			SourceHost:   sourceHost,
+			SourcePort:   sourcePort,
+			ReplUser:     replUser,
+			ReplPassword: replPassword,
+			BinlogFile:   meta.BinlogFile,
+			BinlogPos:    meta.BinlogPosition,
+			GTIDSet:      meta.GTIDSet,
+		}
+		if info.SourceHost == "" {
+			info.SourceHost = meta.MySQLHost
+		}
+		if info.SourcePort == 0 {
+			info.SourcePort = meta.MySQLPort
+		}
+		sqlText, err := load.BuildReplicationSQL(info)
+		if err != nil {
+			log.Fatalf("--show-replication: %v", err)
+		}
+		fmt.Print(sqlText)
+		return
 	}
 
 	db, err := connect(host, port, user, password, socket, database)

--- a/cmd/go-load/main.go
+++ b/cmd/go-load/main.go
@@ -40,6 +40,10 @@ func main() {
 		verify        bool
 		resume        bool
 		showRepl      bool
+		startRepl     bool
+		replMode      string
+		sourceSSL     bool
+		getSourcePubK bool
 		sourceHost    string
 		sourcePort    int
 		replUser      string
@@ -67,10 +71,14 @@ func main() {
 	flag.BoolVar(&verify, "verify", false, "Verify checksums after loading (requires checksums.txt in --directory)")
 	flag.BoolVar(&resume, "resume", false, "Resume a previous load: skip files recorded in load-state.json and continue partially-loaded data files after their last committed statement. --workers may differ between runs.")
 	flag.BoolVar(&showRepl, "show-replication", false, "Print ready-to-run replication setup SQL (GTID AUTO_POSITION and binlog file/position) parsed from the dump's metadata.json in --directory, then exit. Connects to nothing and executes nothing.")
-	flag.StringVar(&sourceHost, "source-host", "", "With --show-replication: source host for the statements (default: mysql_host from metadata.json — override when the replica reaches the source by another address)")
-	flag.IntVar(&sourcePort, "source-port", 0, "With --show-replication: source port (default: mysql_port from metadata.json, else 3306)")
-	flag.StringVar(&replUser, "repl-user", "", "With --show-replication: replication user for the statements (default: <repl_user> placeholder)")
-	flag.StringVar(&replPassword, "repl-password", "", "With --show-replication: replication password (or set GOLOAD_REPL_PASSWORD env var; default: <repl_password> placeholder)")
+	flag.BoolVar(&startRepl, "start-replication", false, "After the load, configure the target as a replica of the dump source (CHANGE REPLICATION SOURCE from metadata.json coordinates), START REPLICA, and wait for both threads to come up. Requires --repl-user. GTID mode requires gtid_executed to equal the dump's set — pair with --set-gtid-purged.")
+	flag.StringVar(&replMode, "replication-mode", "auto", "With --start-replication: auto (GTID auto-position when the dump has a GTID set and the target has gtid_mode=ON, else binlog file/position), gtid, or file-pos")
+	flag.BoolVar(&sourceSSL, "source-ssl", false, "With --start-replication: add SOURCE_SSL=1 (encrypt the replication connection)")
+	flag.BoolVar(&getSourcePubK, "get-source-public-key", false, "With --start-replication: add GET_SOURCE_PUBLIC_KEY=1 — needed when the replication user authenticates with caching_sha2_password and the connection is not TLS")
+	flag.StringVar(&sourceHost, "source-host", "", "With --show-replication/--start-replication: source host (default: mysql_host from metadata.json — override when the replica reaches the source by another address)")
+	flag.IntVar(&sourcePort, "source-port", 0, "With --show-replication/--start-replication: source port (default: mysql_port from metadata.json, else 3306)")
+	flag.StringVar(&replUser, "repl-user", "", "With --show-replication/--start-replication: replication user (required for --start-replication; <repl_user> placeholder in --show-replication output)")
+	flag.StringVar(&replPassword, "repl-password", "", "With --show-replication/--start-replication: replication password (or set GOLOAD_REPL_PASSWORD env var)")
 	flag.BoolVar(&quiet, "quiet", false, "Suppress INFO messages")
 	flag.BoolVar(&debug, "debug", false, "Print debug information")
 	flag.StringVar(&iniFile, "ini-file", "", "INI configuration file (supports [client] and [go-load] sections)")
@@ -111,6 +119,17 @@ func main() {
 	if setGtidPurged && directory == "" {
 		log.Fatal("--set-gtid-purged requires --directory (the GTID set comes from the dump's metadata.json).")
 	}
+	if startRepl && directory == "" {
+		log.Fatal("--start-replication requires --directory (coordinates come from the dump's metadata.json).")
+	}
+	if startRepl && replUser == "" {
+		log.Fatal("--start-replication requires --repl-user (an account on the source with REPLICATION SLAVE).")
+	}
+	if replPassword == "" {
+		if env := os.Getenv("GOLOAD_REPL_PASSWORD"); env != "" {
+			replPassword = env
+		}
+	}
 
 	// --show-replication: parse metadata.json, print the setup SQL, exit.
 	// Read-only — no MySQL connection, no load. Output goes to stdout so it
@@ -125,11 +144,6 @@ func main() {
 		}
 		if meta.Status != "complete" {
 			log.Warningf("Dump status is %q, not \"complete\" — its coordinates may not describe a restorable dump.", meta.Status)
-		}
-		if replPassword == "" {
-			if env := os.Getenv("GOLOAD_REPL_PASSWORD"); env != "" {
-				replPassword = env
-			}
 		}
 		info := load.ReplicationInfo{
 			SourceHost:   sourceHost,
@@ -201,6 +215,15 @@ func main() {
 				log.Fatal("--set-gtid-purged: metadata.json has no gtid_set — the dump was taken without --get-master-status, or the source has no GTIDs.")
 			}
 		}
+		if startRepl {
+			// Same principle: refuse before the load starts, not after hours of it.
+			if metaErr != nil {
+				log.Fatalf("--start-replication: cannot read metadata.json: %v", metaErr)
+			}
+			if meta.GTIDSet == "" && meta.BinlogFile == "" {
+				log.Fatal("--start-replication: metadata.json has no replication coordinates — the dump was taken without --get-master-status.")
+			}
+		}
 
 		var ls *load.LoadState
 		if resume {
@@ -226,6 +249,35 @@ func main() {
 		if setGtidPurged {
 			log.Info("Applying the dump's GTID set to the target (--set-gtid-purged)...")
 			if err := load.ApplyGTIDPurged(ctx, db, meta.GTIDSet, force); err != nil {
+				log.Fatalf("%v", err)
+			}
+		}
+
+		if startRepl {
+			log.Info("Configuring and starting replication on the target (--start-replication)...")
+			info := load.ReplicationInfo{
+				SourceHost:   sourceHost,
+				SourcePort:   sourcePort,
+				ReplUser:     replUser,
+				ReplPassword: replPassword,
+				BinlogFile:   meta.BinlogFile,
+				BinlogPos:    meta.BinlogPosition,
+				GTIDSet:      meta.GTIDSet,
+			}
+			if info.SourceHost == "" {
+				info.SourceHost = meta.MySQLHost
+				log.Warningf("--source-host not given — using mysql_host from metadata.json (%s). "+
+					"That is the address the DUMP used; override it if the replica reaches the source differently.", info.SourceHost)
+			}
+			if info.SourcePort == 0 {
+				info.SourcePort = meta.MySQLPort
+			}
+			if err := load.StartReplication(ctx, db, info, load.StartOptions{
+				Mode:               replMode,
+				SourceSSL:          sourceSSL,
+				GetSourcePublicKey: getSourcePubK,
+				Force:              force,
+			}); err != nil {
 				log.Fatalf("%v", err)
 			}
 		}

--- a/docs/GTID-REPLICATION.md
+++ b/docs/GTID-REPLICATION.md
@@ -1,7 +1,9 @@
 # GTID & Replication: current state, gaps, and planned features
 
-Status of GTID handling in go-dump/go-load as of 2026-07-03, and the work needed
-to make replica seeding a one-command operation.
+Status of GTID handling in go-dump/go-load as of 2026-07-19. Replica seeding
+is now a one-command operation (`go-load --skip-binlog --set-gtid-purged
+--start-replication`); this document tracks how each piece works and what
+remains open.
 
 ## What works today
 
@@ -13,8 +15,8 @@ to make replica seeding a one-command operation.
   `GetTransactions`). The recorded binlog file/position and `Executed_Gtid_Set`
   therefore match the dumped data exactly — correct for replica seeding.
 - Coordinates are persisted twice:
-  - `metadata.json` → `binlog_file`, `binlog_position`, `gtid_set`
-    (`internal/dump/metadata.go`, `SetBinlog`)
+  - `metadata.json` → `mysql_host`, `mysql_port` (0.3.0+), `binlog_file`,
+    `binlog_position`, `gtid_set` (`internal/dump/metadata.go`, `SetBinlog`)
   - `master-data.sql` → human-readable text report
 - `--get-slave-status` records `SHOW REPLICA STATUS` (incl. `Executed_Gtid_Set`
   / MariaDB `Gtid_Slave_Pos`, multi-source aware) to `slave-data.sql` — useful
@@ -40,8 +42,10 @@ to make replica seeding a one-command operation.
 - `go-load --set-gtid-purged` applies the dump's GTID set to the target after
   the load, with errant-transaction and running-replica guards
   (`internal/load/gtid.go`) — see item 1 below.
-- Only `CHANGE REPLICATION SOURCE TO` + `START REPLICA` remain manual, and the
-  dump ships a filled-in template (`change-replication-source.sql`) for them.
+- `CHANGE REPLICATION SOURCE TO` + `START REPLICA` can run three ways:
+  automatically (`go-load --start-replication`, item 3 below), from printed
+  SQL reviewed by the operator (`go-load --show-replication`), or from the
+  dump's filled-in template (`change-replication-source.sql`).
 
 ## Gaps / planned features
 
@@ -90,7 +94,7 @@ nothing to `gtid_executed`, so `RESET MASTER` may be skippable when the target
 started empty. `--set-gtid-purged` should check `@@gtid_executed` at runtime
 instead of assuming.
 
-### 3. `go-load --change-source` / emit a helper script at dump time
+### 3. `go-load --start-replication` / `--show-replication` — ✅ DONE (2026-07-19)
 
 - **Dump-time template — ✅ DONE (2026-07-03):** with `--get-master-status`,
   go-dump writes `change-replication-source.sql`
@@ -98,12 +102,42 @@ instead of assuming.
   GTID auto-position as the active statements, 5.7 and file/position variants
   commented. Always plain (never gzipped); go-load's `findFiles` skips it
   during restore.
-- **Load-time `--change-source` — still open:** `go-load --change-source
-  --source-host ... --source-user ... --source-password-env ...` runs
-  `CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1` + `START REPLICA`
-  after `--set-gtid-purged`, then polls `SHOW REPLICA STATUS` until the
-  threads run or a timeout. Version-gate the syntax (`CHANGE MASTER TO` +
-  `MASTER_AUTO_POSITION`, `START SLAVE` on 5.7).
+- **`go-load --show-replication` — ✅ DONE (2026-07-19):** read-only; parses
+  `metadata.json` (never scrapes SQL comments) and prints ready-to-run setup
+  SQL to a clean stdout: GTID auto-position runnable, file/position and 5.7
+  `CHANGE MASTER` as commented variants. `--source-host/--source-port/
+  --repl-user/--repl-password` (or `GOLOAD_REPL_PASSWORD`) fill in what
+  metadata cannot know; placeholders otherwise. GTID set is validated by the
+  same sanitizer as `--set-gtid-purged` before being embedded in SQL
+  (`internal/load/replication.go`, `BuildReplicationSQL`).
+- **`go-load --start-replication` — ✅ DONE (2026-07-19):** executes the setup
+  after the load (and after `--verify` / `--set-gtid-purged`):
+  - `--replication-mode auto|gtid|file-pos`: auto prefers GTID auto-position
+    when the dump has a `gtid_set` and the target has `gtid_mode=ON`, else
+    binlog file/position; explicit modes fail loudly on missing prerequisites
+    (`chooseReplMode`).
+  - Version-gated syntax: `CHANGE REPLICATION SOURCE TO` + `SOURCE_*` +
+    `START REPLICA` on 8.0.23+; `CHANGE MASTER TO` + `MASTER_*` +
+    `START SLAVE` on 5.7/pre-8.0.23; `GET_SOURCE_PUBLIC_KEY` vs
+    `GET_MASTER_PUBLIC_KEY`, omitted entirely before 8.0.4
+    (`buildChangeSourceSQL`).
+  - Safety gates mirror `--set-gtid-purged`: running channel always aborts;
+    configured-but-stopped channel requires `--force`; GTID mode requires
+    `gtid_executed` to **exactly equal** the dump's set (checked with
+    `GTID_SUBTRACT` in both directions — missing GTIDs would make
+    AUTO_POSITION re-fetch rows the load already inserted; extra GTIDs are
+    errant).
+  - `--source-ssl` (`SOURCE_SSL=1`) and `--get-source-public-key` cover
+    `caching_sha2_password` sources without TLS.
+  - After `START REPLICA`, polls replica status (15s bound): both threads
+    `Yes` → success with lag reported; `Last_IO_Error`/`Last_SQL_Error` →
+    immediate hard error (bad credentials surface in seconds, not as a green
+    exit); still `Connecting` at timeout → error with thread states.
+  - Passwords are redacted from every logged statement.
+  - Validated 2026-07-19 against 8.0.46 source → 8.4 replica: one-command
+    seeding (GTID auto-position, 0s behind, new writes applied), wrong
+    password surfaced `Access denied` as a hard error, `file-pos` mode came
+    up with `Auto_Position: 0`.
 
 ### 4. Rename `master-data.sql` / `slave-data.sql` → `.txt`
 
@@ -152,6 +186,7 @@ needs `SET GLOBAL gtid_slave_pos = '...'` +
 2. ~~Dump-time `change-replication-source.sql` template (item 3)~~ — ✅ done
    2026-07-03.
 3. ~~`go-load --set-gtid-purged` (item 1)~~ — ✅ done 2026-07-03.
-4. `go-load --change-source` (item 3, load-time half) — next up.
+4. ~~`go-load --start-replication` + `--show-replication` (item 3, load-time
+   half)~~ — ✅ done 2026-07-19.
 5. File rename (item 4), MariaDB flavor support (item 5), and
    `--set-gtid-purged=append` as follow-ups.

--- a/internal/dump/dumper.go
+++ b/internal/dump/dumper.go
@@ -111,6 +111,7 @@ func Run(ctx context.Context, opts *DumpOptions) {
 			opts.DestinationDir,
 			opts.AppVersion,
 			opts.MySQLHost.HostName,
+			opts.MySQLHost.Port,
 			taskManager.MySQLVersion(),
 		)
 		activeMeta = meta

--- a/internal/dump/metadata.go
+++ b/internal/dump/metadata.go
@@ -34,6 +34,7 @@ type DumpMetadata struct {
 	EndTime        *time.Time       `json:"end_time,omitempty"`
 	Status         string           `json:"status"` // "in_progress" | "complete" | "failed"
 	MySQLHost      string           `json:"mysql_host"`
+	MySQLPort      int              `json:"mysql_port,omitempty"`
 	MySQLVersion   string           `json:"mysql_version"`
 	BinlogFile     string           `json:"binlog_file,omitempty"`
 	BinlogPosition int              `json:"binlog_position,omitempty"`
@@ -47,12 +48,13 @@ type DumpMetadata struct {
 }
 
 // NewDumpMetadata initialises a metadata object and writes the initial in_progress file.
-func NewDumpMetadata(destDir, appVersion, mysqlHost, mysqlVersion string) *DumpMetadata {
+func NewDumpMetadata(destDir, appVersion, mysqlHost string, mysqlPort int, mysqlVersion string) *DumpMetadata {
 	m := &DumpMetadata{
 		GoDumpVersion: appVersion,
 		StartTime:     time.Now().UTC(),
 		Status:        "in_progress",
 		MySQLHost:     mysqlHost,
+		MySQLPort:     mysqlPort,
 		MySQLVersion:  mysqlVersion,
 		CharacterSet:  "utf8mb4",
 		path:          destDir + "/metadata.json",

--- a/internal/dump/metadata_test.go
+++ b/internal/dump/metadata_test.go
@@ -12,7 +12,7 @@ import (
 func TestDumpMetadataLifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	meta := NewDumpMetadata(dir, "1.0.0", "db01.example.com", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "db01.example.com", 3306, "8.0.43")
 	if meta.Status != "in_progress" {
 		t.Fatalf("expected status in_progress, got %s", meta.Status)
 	}
@@ -83,7 +83,7 @@ func TestDumpMetadataLifecycle(t *testing.T) {
 
 func TestDumpMetadataFail(t *testing.T) {
 	dir := t.TempDir()
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	meta.Fail()
 
 	loaded, err := LoadDumpMetadata(dir)
@@ -100,7 +100,7 @@ func TestDumpMetadataFail(t *testing.T) {
 
 func TestDumpMetadataSetChecksum(t *testing.T) {
 	dir := t.TempDir()
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	meta.AddTable("db", "tbl", 1000)
 	meta.SetChecksum("db", "tbl", 987654321)
 	_ = meta.Write()
@@ -155,7 +155,7 @@ func TestLoadDumpMetadata_Corrupt(t *testing.T) {
 
 func TestDumpMetadataAtomicWrite(t *testing.T) {
 	dir := t.TempDir()
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 
 	// Write several times rapidly — no tmp file should be left behind.
 	for i := 0; i < 20; i++ {
@@ -185,7 +185,7 @@ func TestDumpMetadataAtomicWrite(t *testing.T) {
 func TestDumpMetadataStartTime(t *testing.T) {
 	before := time.Now().UTC().Add(-time.Second)
 	dir := t.TempDir()
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	after := time.Now().UTC().Add(time.Second)
 
 	if meta.StartTime.Before(before) || meta.StartTime.After(after) {

--- a/internal/dump/resume_test.go
+++ b/internal/dump/resume_test.go
@@ -75,7 +75,7 @@ func TestApplyResumeFilter_SkipsDone(t *testing.T) {
 	dir := t.TempDir()
 
 	// Write a prior metadata.json with one done table and one pending.
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	meta.AddTable("db", "tableA", 1000)
 	meta.AddTable("db", "tableB", 2000)
 	meta.MarkTableDone("db", "tableA", 10)
@@ -104,7 +104,7 @@ func TestApplyResumeFilter_SkipsDone(t *testing.T) {
 func TestApplyResumeFilter_CleanPartialFiles(t *testing.T) {
 	dir := t.TempDir()
 
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	meta.AddTable("db", "orders", 1000) // pending — partial files should be cleaned
 	_ = meta.Write()
 
@@ -125,7 +125,7 @@ func TestApplyResumeFilter_CleanPartialFiles(t *testing.T) {
 func TestApplyResumeFilter_AllDone(t *testing.T) {
 	dir := t.TempDir()
 
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	meta.AddTable("db", "tableA", 1000)
 	meta.MarkTableDone("db", "tableA", 10)
 	meta.Complete()
@@ -142,13 +142,13 @@ func TestApplyResumeFilter_AllDone(t *testing.T) {
 func TestMergeDoneTables(t *testing.T) {
 	dir := t.TempDir()
 
-	prior := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	prior := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	prior.AddTable("db", "done_table", 1000)
 	prior.AddTable("db", "pending_table", 2000)
 	prior.MarkTableDone("db", "done_table", 7)
 	prior.SetChecksum("db", "done_table", 12345)
 
-	fresh := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	fresh := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	fresh.AddTable("db", "pending_table", 2000) // re-dumped this run
 	fresh.MergeDoneTables(prior)
 
@@ -181,7 +181,7 @@ func TestMergeDoneTables(t *testing.T) {
 
 func TestMaybeMarkDone(t *testing.T) {
 	dir := t.TempDir()
-	meta := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	meta.AddTable("db", "t1", 100)
 
 	tm := &TaskManager{metadata: meta}
@@ -209,7 +209,7 @@ func TestMaybeMarkDone(t *testing.T) {
 	}
 
 	// Compressed dumps defer marking to the final sweep.
-	meta2 := NewDumpMetadata(dir, "1.0.0", "host", "8.0.43")
+	meta2 := NewDumpMetadata(dir, "1.0.0", "host", 3306, "8.0.43")
 	meta2.AddTable("db", "t2", 100)
 	tmC := &TaskManager{metadata: meta2, Compress: true}
 	taskC := &Task{Table: &Table{schema: "db", name: "t2"}, TaskManager: tmC}

--- a/internal/load/replication.go
+++ b/internal/load/replication.go
@@ -1,8 +1,13 @@
 package load
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/ChaosHour/go-dump/internal/log"
 )
 
 // ReplicationInfo carries everything needed to point a replica seeded from a
@@ -131,4 +136,301 @@ func BuildReplicationSQL(info ReplicationInfo) (string, error) {
 	w("-- START SLAVE;")
 
 	return b.String(), nil
+}
+
+// StartOptions controls StartReplication.
+type StartOptions struct {
+	Mode               string // "auto", "gtid", or "file-pos"
+	SourceSSL          bool   // add SOURCE_SSL = 1 (encrypt the replication connection)
+	GetSourcePublicKey bool   // add GET_SOURCE_PUBLIC_KEY = 1 (caching_sha2_password without TLS)
+	Force              bool   // allow acting on a configured-but-stopped channel
+}
+
+// chooseReplMode resolves the replication mode. "auto" picks GTID
+// auto-position when the dump carries a GTID set and the target has
+// gtid_mode=ON, falling back to file/position otherwise; explicit modes are
+// validated against what the dump and target actually support.
+func chooseReplMode(requested, gtidSet string, gtidModeOn bool, binlogFile string) (string, error) {
+	switch requested {
+	case "auto":
+		if gtidSet != "" && gtidModeOn {
+			return "gtid", nil
+		}
+		if binlogFile == "" {
+			return "", fmt.Errorf("no usable coordinates: the dump has no binlog_file and GTID auto-position is unavailable " +
+				"(dump has no gtid_set or target gtid_mode is not ON)")
+		}
+		return "file-pos", nil
+	case "gtid":
+		if gtidSet == "" {
+			return "", fmt.Errorf("--replication-mode gtid: the dump has no gtid_set (was it taken with --get-master-status on a GTID-enabled source?)")
+		}
+		if !gtidModeOn {
+			return "", fmt.Errorf("--replication-mode gtid: target gtid_mode is not ON")
+		}
+		return "gtid", nil
+	case "file-pos":
+		if binlogFile == "" {
+			return "", fmt.Errorf("--replication-mode file-pos: the dump has no binlog_file (was it taken with --get-master-status?)")
+		}
+		return "file-pos", nil
+	default:
+		return "", fmt.Errorf("--replication-mode must be auto, gtid, or file-pos (got %q)", requested)
+	}
+}
+
+// buildChangeSourceSQL renders the CHANGE statement for the target server
+// version, plus a copy with the password redacted for logging.
+func buildChangeSourceSQL(v [3]int, info ReplicationInfo, gtidSet, mode string, opts StartOptions) (stmt, redacted string) {
+	modern := versionAtLeast(v, 8, 0, 23)
+
+	kw := func(modernName, legacyName string) string {
+		if modern {
+			return modernName
+		}
+		return legacyName
+	}
+
+	_ = gtidSet // coordinates travel via AUTO_POSITION; gtid_purged is seeded separately
+
+	build := func(password string) string {
+		var clauses []string
+		add := func(c string) { clauses = append(clauses, c) }
+
+		add(fmt.Sprintf("%s = '%s'", kw("SOURCE_HOST", "MASTER_HOST"), escapeSQLString(info.SourceHost)))
+		port := info.SourcePort
+		if port == 0 {
+			port = 3306
+		}
+		add(fmt.Sprintf("%s = %d", kw("SOURCE_PORT", "MASTER_PORT"), port))
+		add(fmt.Sprintf("%s = '%s'", kw("SOURCE_USER", "MASTER_USER"), escapeSQLString(info.ReplUser)))
+		add(fmt.Sprintf("%s = '%s'", kw("SOURCE_PASSWORD", "MASTER_PASSWORD"), password))
+
+		if opts.SourceSSL {
+			add(fmt.Sprintf("%s = 1", kw("SOURCE_SSL", "MASTER_SSL")))
+		}
+		// GET_MASTER_PUBLIC_KEY exists from 8.0.4 (caching_sha2_password did
+		// not exist before 8.0); silently skip on older targets.
+		if opts.GetSourcePublicKey && versionAtLeast(v, 8, 0, 4) {
+			add(fmt.Sprintf("%s = 1", kw("GET_SOURCE_PUBLIC_KEY", "GET_MASTER_PUBLIC_KEY")))
+		}
+
+		if mode == "gtid" {
+			add(fmt.Sprintf("%s = 1", kw("SOURCE_AUTO_POSITION", "MASTER_AUTO_POSITION")))
+		} else {
+			add(fmt.Sprintf("%s = '%s'", kw("SOURCE_LOG_FILE", "MASTER_LOG_FILE"), escapeSQLString(info.BinlogFile)))
+			add(fmt.Sprintf("%s = %d", kw("SOURCE_LOG_POS", "MASTER_LOG_POS"), info.BinlogPos))
+		}
+
+		return fmt.Sprintf("%s %s",
+			kw("CHANGE REPLICATION SOURCE TO", "CHANGE MASTER TO"),
+			strings.Join(clauses, ", "))
+	}
+
+	return build(escapeSQLString(info.ReplPassword)), build("<redacted>")
+}
+
+// replicaStatusRow returns the first row of SHOW REPLICA STATUS (SHOW SLAVE
+// STATUS pre-8.0.22) as a column-name → value map, or nil when no channel is
+// configured.
+func replicaStatusRow(ctx context.Context, conn *sql.Conn, v [3]int) (map[string]string, error) {
+	stmt := "SHOW SLAVE STATUS"
+	if versionAtLeast(v, 8, 0, 22) {
+		stmt = "SHOW REPLICA STATUS"
+	}
+	rows, err := conn.QueryContext(ctx, stmt)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", stmt, err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	if !rows.Next() {
+		return nil, rows.Err()
+	}
+	vals := make([]any, len(cols))
+	for i := range vals {
+		vals[i] = new(sql.RawBytes)
+	}
+	if err := rows.Scan(vals...); err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, len(cols))
+	for i, c := range cols {
+		if rb, ok := vals[i].(*sql.RawBytes); ok {
+			m[strings.ToUpper(c)] = string(*rb)
+		}
+	}
+	return m, nil
+}
+
+// statusField reads a replica-status field that differs only by the
+// Replica_/Slave_ prefix across versions.
+func statusField(m map[string]string, suffix string) string {
+	for k, v := range m {
+		if strings.HasSuffix(k, suffix) {
+			return v
+		}
+	}
+	return ""
+}
+
+// assessReplicaStatus interprets one status row: healthy (both threads
+// running), a hard error (either Last_*_Error set), or still starting.
+func assessReplicaStatus(m map[string]string) (healthy bool, hardErr string, state string) {
+	io := statusField(m, "_IO_RUNNING")
+	sqlThread := statusField(m, "_SQL_RUNNING")
+	if e := m["LAST_IO_ERROR"]; e != "" {
+		return false, "IO thread: " + e, ""
+	}
+	if e := m["LAST_SQL_ERROR"]; e != "" {
+		return false, "SQL thread: " + e, ""
+	}
+	if strings.EqualFold(io, "Yes") && strings.EqualFold(sqlThread, "Yes") {
+		return true, "", ""
+	}
+	return false, "", fmt.Sprintf("IO thread: %s, SQL thread: %s", io, sqlThread)
+}
+
+// startReplicaHealthTimeout bounds how long StartReplication waits for both
+// threads to report running before giving up. The IO thread legitimately
+// reports "Connecting" for a few seconds on first start.
+const startReplicaHealthTimeout = 15 * time.Second
+
+// StartReplication configures the target as a replica of the dump source and
+// starts it, then waits for both threads to come up healthy.
+//
+// Safety gates, matching ApplyGTIDPurged:
+//   - a RUNNING replication channel always aborts;
+//   - a configured-but-stopped channel requires force;
+//   - in GTID mode, the target's gtid_executed must equal the dump's GTID set
+//     (seed it with --set-gtid-purged) — anything less re-fetches rows the
+//     load already inserted, anything more is errant.
+func StartReplication(ctx context.Context, db *sql.DB, info ReplicationInfo, opts StartOptions) error {
+	if info.SourceHost == "" {
+		return fmt.Errorf("--start-replication: no source host: metadata.json has no mysql_host and --source-host was not given")
+	}
+	if info.ReplUser == "" {
+		return fmt.Errorf("--start-replication: --repl-user is required")
+	}
+
+	gtidSet := ""
+	if info.GTIDSet != "" {
+		s, err := sanitizeGTIDSet(info.GTIDSet)
+		if err != nil {
+			return fmt.Errorf("--start-replication: gtid_set in metadata.json: %w", err)
+		}
+		gtidSet = s
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("--start-replication: acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	v, err := serverVersion(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("--start-replication: %w", err)
+	}
+
+	configured, running, err := replicaConfigured(ctx, conn, v)
+	if err != nil {
+		return fmt.Errorf("--start-replication: %w", err)
+	}
+	if running {
+		return fmt.Errorf("--start-replication: target has a RUNNING replication channel. " +
+			"Refusing to reconfigure an active replica — STOP REPLICA first if you really mean to re-point it")
+	}
+	if configured && !opts.Force {
+		return fmt.Errorf("--start-replication: target has a configured (stopped) replication channel. " +
+			"Re-run with --force if you are deliberately re-pointing this replica")
+	}
+
+	var gtidMode string
+	if err := conn.QueryRowContext(ctx, "SELECT @@global.gtid_mode").Scan(&gtidMode); err != nil {
+		// 5.6+ always has gtid_mode; treat a read failure as fatal rather than guessing.
+		return fmt.Errorf("--start-replication: read gtid_mode: %w", err)
+	}
+
+	mode, err := chooseReplMode(opts.Mode, gtidSet, strings.EqualFold(gtidMode, "ON"), info.BinlogFile)
+	if err != nil {
+		return fmt.Errorf("--start-replication: %w", err)
+	}
+	log.Infof("Replication mode: %s", mode)
+
+	if mode == "gtid" {
+		// AUTO_POSITION replicates everything the target's GTID state does not
+		// cover — that state must exactly equal the dump's snapshot set.
+		var missing, extra string
+		if err := conn.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT GTID_SUBTRACT('%s', @@global.gtid_executed), GTID_SUBTRACT(@@global.gtid_executed, '%s')", gtidSet, gtidSet),
+		).Scan(&missing, &extra); err != nil {
+			return fmt.Errorf("--start-replication: GTID state check: %w", err)
+		}
+		missing = strings.Join(strings.Fields(missing), "")
+		extra = strings.Join(strings.Fields(extra), "")
+		if extra != "" {
+			return fmt.Errorf("--start-replication: target has transactions beyond the dump's GTID set: %s. "+
+				"Errant transactions or a non-empty target — inspect with go-gtids before replicating", extra)
+		}
+		if missing != "" {
+			return fmt.Errorf("--start-replication: target gtid_executed does not cover the dump's GTID set (missing %s). "+
+				"AUTO_POSITION would re-fetch transactions whose rows the load already inserted — "+
+				"seed the GTID state first with --set-gtid-purged", missing)
+		}
+	}
+
+	changeStmt, redacted := buildChangeSourceSQL(v, info, gtidSet, mode, opts)
+	log.Infof("Executing: %s", redacted)
+	if _, err := conn.ExecContext(ctx, changeStmt); err != nil {
+		return fmt.Errorf("--start-replication: %s: %w", redacted, err)
+	}
+
+	startStmt := "START SLAVE"
+	if versionAtLeast(v, 8, 0, 22) {
+		startStmt = "START REPLICA"
+	}
+	log.Infof("Executing: %s", startStmt)
+	if _, err := conn.ExecContext(ctx, startStmt); err != nil {
+		return fmt.Errorf("--start-replication: %s: %w", startStmt, err)
+	}
+
+	// Wait for both threads: "Connecting" is normal for a few seconds, a
+	// Last_*_Error (bad credentials, missing binlogs, apply failure) is not.
+	deadline := time.Now().Add(startReplicaHealthTimeout)
+	var lastState string
+	for {
+		m, err := replicaStatusRow(ctx, conn, v)
+		if err != nil {
+			return fmt.Errorf("--start-replication: %w", err)
+		}
+		if m != nil {
+			healthy, hardErr, state := assessReplicaStatus(m)
+			if healthy {
+				behind := statusField(m, "SECONDS_BEHIND_SOURCE")
+				if behind == "" {
+					behind = statusField(m, "SECONDS_BEHIND_MASTER")
+				}
+				log.Infof("Replication running: IO=Yes SQL=Yes, seconds behind source: %s", behind)
+				return nil
+			}
+			if hardErr != "" {
+				return fmt.Errorf("--start-replication: replication failed to start — %s", hardErr)
+			}
+			lastState = state
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("--start-replication: replication threads not both running after %s (%s). "+
+				"Check SHOW REPLICA STATUS on the target", startReplicaHealthTimeout, lastState)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
 }

--- a/internal/load/replication.go
+++ b/internal/load/replication.go
@@ -1,0 +1,134 @@
+package load
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReplicationInfo carries everything needed to point a replica seeded from a
+// dump at the dump's source server. Coordinates come from the dump's
+// metadata.json; host, port, user, and password may be overridden by flags
+// when the replica reaches the source by a different address or account.
+type ReplicationInfo struct {
+	SourceHost   string
+	SourcePort   int
+	ReplUser     string // "<repl_user>" placeholder when empty
+	ReplPassword string // "<repl_password>" placeholder when empty
+	BinlogFile   string
+	BinlogPos    int
+	GTIDSet      string // raw from metadata.json; sanitised and validated here
+}
+
+// escapeSQLString escapes a value for embedding in a single-quoted MySQL
+// string literal: backslashes and single quotes are backslash-escaped.
+func escapeSQLString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	return strings.ReplaceAll(s, `'`, `\'`)
+}
+
+// BuildReplicationSQL renders ready-to-run replication setup statements from
+// the dump's recorded coordinates. Nothing is executed — the output is for
+// the operator to review and run manually (or pipe into the mysql client).
+//
+// When the dump carries a GTID set, the GTID AUTO_POSITION variant is emitted
+// as the runnable block and file/position as a commented alternative;
+// without a GTID set, file/position is the runnable block. The MySQL 5.7
+// CHANGE MASTER syntax is always included as a commented block.
+func BuildReplicationSQL(info ReplicationInfo) (string, error) {
+	if info.SourceHost == "" {
+		return "", fmt.Errorf("no source host: metadata.json has no mysql_host and --source-host was not given")
+	}
+
+	gtidSet := ""
+	if info.GTIDSet != "" {
+		s, err := sanitizeGTIDSet(info.GTIDSet)
+		if err != nil {
+			return "", fmt.Errorf("gtid_set in metadata.json: %w", err)
+		}
+		gtidSet = s
+	}
+	if gtidSet == "" && info.BinlogFile == "" {
+		return "", fmt.Errorf("the dump has no replication coordinates (no gtid_set, no binlog_file) — " +
+			"was it taken with --get-master-status?")
+	}
+
+	port := info.SourcePort
+	if port == 0 {
+		port = 3306
+	}
+	user := "<repl_user>"
+	if info.ReplUser != "" {
+		user = escapeSQLString(info.ReplUser)
+	}
+	password := "<repl_password>"
+	if info.ReplPassword != "" {
+		password = escapeSQLString(info.ReplPassword)
+	}
+	host := escapeSQLString(info.SourceHost)
+
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+
+	w("-- Replication setup for a replica seeded from this dump.")
+	w("-- Coordinates parsed from metadata.json (captured inside the dump's lock window).")
+	w("--   Source:               %s:%d", info.SourceHost, port)
+	if info.BinlogFile != "" {
+		w("--   Binlog file/position: %s:%d", info.BinlogFile, info.BinlogPos)
+	}
+	if gtidSet != "" {
+		w("--   Executed GTID set:    %s", gtidSet)
+	}
+	w("--")
+	w("-- Review before running. If the source uses caching_sha2_password without")
+	w("-- TLS, add GET_SOURCE_PUBLIC_KEY = 1 to the CHANGE statement.")
+
+	changeHeader := func(commented bool) {
+		p := ""
+		if commented {
+			p = "-- "
+		}
+		w("%sCHANGE REPLICATION SOURCE TO", p)
+		w("%s  SOURCE_HOST = '%s',", p, host)
+		w("%s  SOURCE_PORT = %d,", p, port)
+		w("%s  SOURCE_USER = '%s',", p, user)
+		w("%s  SOURCE_PASSWORD = '%s',", p, password)
+	}
+
+	if gtidSet != "" {
+		w("")
+		w("-- ── GTID auto-position (MySQL 8.0.23+ syntax) ──")
+		w("-- Prerequisite: the target's gtid_executed must equal the dump's GTID set.")
+		w("-- go-load --set-gtid-purged does this with safety checks; to do it by hand")
+		w("-- on a target with EMPTY gtid_executed, uncomment:")
+		w("-- SET GLOBAL gtid_purged = '%s';", gtidSet)
+		changeHeader(false)
+		w("  SOURCE_AUTO_POSITION = 1;")
+		w("START REPLICA;")
+		w("")
+		w("-- ── File/position alternative (gtid_mode=OFF topologies) ──")
+		changeHeader(true)
+		w("--   SOURCE_LOG_FILE = '%s',", info.BinlogFile)
+		w("--   SOURCE_LOG_POS = %d;", info.BinlogPos)
+		w("-- START REPLICA;")
+	} else {
+		w("")
+		w("-- ── File/position (dump has no GTID set) ──")
+		changeHeader(false)
+		w("  SOURCE_LOG_FILE = '%s',", info.BinlogFile)
+		w("  SOURCE_LOG_POS = %d;", info.BinlogPos)
+		w("START REPLICA;")
+	}
+
+	w("")
+	w("-- ── MySQL 5.7 / pre-8.0.23 syntax ──")
+	w("-- CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d,", host, port)
+	w("--   MASTER_USER='%s', MASTER_PASSWORD='%s',", user, password)
+	if gtidSet != "" {
+		w("--   MASTER_AUTO_POSITION=1;")
+	} else {
+		w("--   MASTER_LOG_FILE='%s', MASTER_LOG_POS=%d;", info.BinlogFile, info.BinlogPos)
+	}
+	w("-- START SLAVE;")
+
+	return b.String(), nil
+}

--- a/internal/load/replication_test.go
+++ b/internal/load/replication_test.go
@@ -132,3 +132,147 @@ func TestEscapeSQLString(t *testing.T) {
 		}
 	}
 }
+
+// --- StartReplication pure helpers ---
+
+func TestChooseReplMode(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested string
+		gtidSet   string
+		gtidOn    bool
+		binlog    string
+		want      string
+		wantErr   bool
+	}{
+		{"auto prefers gtid", "auto", "uuid:1-5", true, "b.1", "gtid", false},
+		{"auto falls back when gtid_mode off", "auto", "uuid:1-5", false, "b.1", "file-pos", false},
+		{"auto falls back when no gtid set", "auto", "", true, "b.1", "file-pos", false},
+		{"auto with nothing usable", "auto", "", false, "", "", true},
+		{"explicit gtid ok", "gtid", "uuid:1-5", true, "", "gtid", false},
+		{"explicit gtid without set", "gtid", "", true, "b.1", "", true},
+		{"explicit gtid mode off", "gtid", "uuid:1-5", false, "b.1", "", true},
+		{"explicit file-pos ok", "file-pos", "uuid:1-5", true, "b.1", "file-pos", false},
+		{"explicit file-pos without binlog", "file-pos", "uuid:1-5", true, "", "", true},
+		{"bogus mode", "chaos", "uuid:1-5", true, "b.1", "", true},
+	}
+	for _, c := range cases {
+		got, err := chooseReplMode(c.requested, c.gtidSet, c.gtidOn, c.binlog)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got mode %q", c.name, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", c.name, err)
+		} else if got != c.want {
+			t.Errorf("%s: mode = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestBuildChangeSourceSQL_ModernGTID(t *testing.T) {
+	info := ReplicationInfo{
+		SourceHost: "primary1", SourcePort: 3306,
+		ReplUser: "repl", ReplPassword: "s'cret",
+		BinlogFile: "b.1", BinlogPos: 4,
+	}
+	stmt, redacted := buildChangeSourceSQL([3]int{8, 0, 43}, info, "u:1-5", "gtid",
+		StartOptions{SourceSSL: true, GetSourcePublicKey: true})
+
+	for _, want := range []string{
+		"CHANGE REPLICATION SOURCE TO",
+		"SOURCE_HOST = 'primary1'",
+		"SOURCE_PORT = 3306",
+		"SOURCE_USER = 'repl'",
+		`SOURCE_PASSWORD = 's\'cret'`,
+		"SOURCE_SSL = 1",
+		"GET_SOURCE_PUBLIC_KEY = 1",
+		"SOURCE_AUTO_POSITION = 1",
+	} {
+		if !strings.Contains(stmt, want) {
+			t.Errorf("stmt missing %q:\n%s", want, stmt)
+		}
+	}
+	if strings.Contains(stmt, "SOURCE_LOG_FILE") {
+		t.Error("gtid mode must not set SOURCE_LOG_FILE")
+	}
+	if strings.Contains(redacted, "cret") || !strings.Contains(redacted, "<redacted>") {
+		t.Errorf("redacted statement leaks the password:\n%s", redacted)
+	}
+}
+
+func TestBuildChangeSourceSQL_LegacyFilePos(t *testing.T) {
+	info := ReplicationInfo{
+		SourceHost: "primary1",
+		ReplUser:   "repl", ReplPassword: "x",
+		BinlogFile: "mysql-bin.000007", BinlogPos: 98765,
+	}
+	stmt, _ := buildChangeSourceSQL([3]int{5, 7, 44}, info, "", "file-pos",
+		StartOptions{GetSourcePublicKey: true})
+
+	for _, want := range []string{
+		"CHANGE MASTER TO",
+		"MASTER_HOST = 'primary1'",
+		"MASTER_PORT = 3306", // default port
+		"MASTER_LOG_FILE = 'mysql-bin.000007'",
+		"MASTER_LOG_POS = 98765",
+	} {
+		if !strings.Contains(stmt, want) {
+			t.Errorf("stmt missing %q:\n%s", want, stmt)
+		}
+	}
+	// 5.7 has no caching_sha2_password: the public-key clause must be omitted.
+	if strings.Contains(stmt, "PUBLIC_KEY") {
+		t.Errorf("5.7 statement must not contain a public-key clause:\n%s", stmt)
+	}
+	if strings.Contains(stmt, "SOURCE_") {
+		t.Errorf("5.7 statement must use MASTER_* keywords only:\n%s", stmt)
+	}
+}
+
+func TestBuildChangeSourceSQL_LegacyKeywordsUpTo8022(t *testing.T) {
+	info := ReplicationInfo{SourceHost: "h", ReplUser: "r", BinlogFile: "b.1", BinlogPos: 4}
+	stmt, _ := buildChangeSourceSQL([3]int{8, 0, 22}, info, "u:1", "gtid",
+		StartOptions{GetSourcePublicKey: true})
+	if !strings.Contains(stmt, "CHANGE MASTER TO") || !strings.Contains(stmt, "MASTER_AUTO_POSITION = 1") {
+		t.Errorf("8.0.22 must use legacy CHANGE MASTER syntax:\n%s", stmt)
+	}
+	if !strings.Contains(stmt, "GET_MASTER_PUBLIC_KEY = 1") {
+		t.Errorf("8.0.22 supports GET_MASTER_PUBLIC_KEY:\n%s", stmt)
+	}
+}
+
+func TestAssessReplicaStatus(t *testing.T) {
+	healthy, hardErr, _ := assessReplicaStatus(map[string]string{
+		"REPLICA_IO_RUNNING": "Yes", "REPLICA_SQL_RUNNING": "Yes",
+		"LAST_IO_ERROR": "", "LAST_SQL_ERROR": "",
+	})
+	if !healthy || hardErr != "" {
+		t.Errorf("both Yes should be healthy, got healthy=%v err=%q", healthy, hardErr)
+	}
+
+	healthy, hardErr, state := assessReplicaStatus(map[string]string{
+		"REPLICA_IO_RUNNING": "Connecting", "REPLICA_SQL_RUNNING": "Yes",
+	})
+	if healthy || hardErr != "" || !strings.Contains(state, "Connecting") {
+		t.Errorf("Connecting should be still-starting, got healthy=%v err=%q state=%q", healthy, hardErr, state)
+	}
+
+	_, hardErr, _ = assessReplicaStatus(map[string]string{
+		"REPLICA_IO_RUNNING": "No", "REPLICA_SQL_RUNNING": "No",
+		"LAST_IO_ERROR": "Access denied for user 'repl'",
+	})
+	if !strings.Contains(hardErr, "Access denied") {
+		t.Errorf("Last_IO_Error should surface as hard error, got %q", hardErr)
+	}
+
+	// Legacy column names (5.7 / pre-8.0.22).
+	healthy, _, _ = assessReplicaStatus(map[string]string{
+		"SLAVE_IO_RUNNING": "Yes", "SLAVE_SQL_RUNNING": "Yes",
+	})
+	if !healthy {
+		t.Error("legacy Slave_* columns should be recognised")
+	}
+}

--- a/internal/load/replication_test.go
+++ b/internal/load/replication_test.go
@@ -1,0 +1,134 @@
+package load
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildReplicationSQL_GTID(t *testing.T) {
+	out, err := BuildReplicationSQL(ReplicationInfo{
+		SourceHost: "db01.example.com",
+		SourcePort: 3306,
+		ReplUser:   "repl",
+		BinlogFile: "binlog.000042",
+		BinlogPos:  1421,
+		GTIDSet:    "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123",
+	})
+	if err != nil {
+		t.Fatalf("BuildReplicationSQL: %v", err)
+	}
+
+	for _, want := range []string{
+		"SOURCE_HOST = 'db01.example.com',",
+		"SOURCE_PORT = 3306,",
+		"SOURCE_USER = 'repl',",
+		"SOURCE_PASSWORD = '<repl_password>',",
+		"SOURCE_AUTO_POSITION = 1;",
+		"START REPLICA;",
+		"-- SET GLOBAL gtid_purged = '3e11fa47-71ca-11e1-9e33-c80aa9429562:1-123';",
+		"--   SOURCE_LOG_FILE = 'binlog.000042',",
+		"--   SOURCE_LOG_POS = 1421;",
+		"--   MASTER_AUTO_POSITION=1;",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+	// The GTID variant is the runnable block: file/position must only appear commented.
+	if strings.Contains(out, "\n  SOURCE_LOG_FILE") {
+		t.Error("file/position variant should be commented when a GTID set is present")
+	}
+}
+
+func TestBuildReplicationSQL_FilePosOnly(t *testing.T) {
+	out, err := BuildReplicationSQL(ReplicationInfo{
+		SourceHost: "10.0.0.5",
+		BinlogFile: "mysql-bin.000007",
+		BinlogPos:  98765,
+	})
+	if err != nil {
+		t.Fatalf("BuildReplicationSQL: %v", err)
+	}
+	for _, want := range []string{
+		"SOURCE_PORT = 3306,", // default when unset
+		"  SOURCE_LOG_FILE = 'mysql-bin.000007',",
+		"  SOURCE_LOG_POS = 98765;",
+		"SOURCE_USER = '<repl_user>',",
+		"--   MASTER_LOG_FILE='mysql-bin.000007', MASTER_LOG_POS=98765;",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "AUTO_POSITION") && !strings.Contains(out, "-- ") {
+		t.Error("no AUTO_POSITION variant expected without a GTID set")
+	}
+}
+
+func TestBuildReplicationSQL_MultilineGTIDSetSanitised(t *testing.T) {
+	// metadata.json stores the set as MySQL returns it — with embedded newlines.
+	out, err := BuildReplicationSQL(ReplicationInfo{
+		SourceHost: "h",
+		GTIDSet:    "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5,\n4f22fb58-82db-22f2-af44-d91bb540c673:1-9",
+	})
+	if err != nil {
+		t.Fatalf("BuildReplicationSQL: %v", err)
+	}
+	if !strings.Contains(out, "'3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5,4f22fb58-82db-22f2-af44-d91bb540c673:1-9'") {
+		t.Errorf("GTID set not sanitised:\n%s", out)
+	}
+}
+
+func TestBuildReplicationSQL_PasswordEscaped(t *testing.T) {
+	out, err := BuildReplicationSQL(ReplicationInfo{
+		SourceHost:   "h",
+		ReplUser:     "repl",
+		ReplPassword: `p'ss\word`,
+		BinlogFile:   "b.1",
+		BinlogPos:    4,
+	})
+	if err != nil {
+		t.Fatalf("BuildReplicationSQL: %v", err)
+	}
+	if !strings.Contains(out, `SOURCE_PASSWORD = 'p\'ss\\word',`) {
+		t.Errorf("password not escaped:\n%s", out)
+	}
+}
+
+func TestBuildReplicationSQL_NoCoordinates(t *testing.T) {
+	_, err := BuildReplicationSQL(ReplicationInfo{SourceHost: "h"})
+	if err == nil || !strings.Contains(err.Error(), "--get-master-status") {
+		t.Errorf("expected no-coordinates error, got %v", err)
+	}
+}
+
+func TestBuildReplicationSQL_NoHost(t *testing.T) {
+	_, err := BuildReplicationSQL(ReplicationInfo{BinlogFile: "b.1"})
+	if err == nil || !strings.Contains(err.Error(), "source host") {
+		t.Errorf("expected no-host error, got %v", err)
+	}
+}
+
+func TestBuildReplicationSQL_InvalidGTIDSet(t *testing.T) {
+	_, err := BuildReplicationSQL(ReplicationInfo{
+		SourceHost: "h",
+		GTIDSet:    "'; DROP TABLE users; --",
+	})
+	if err == nil {
+		t.Error("expected error for malformed GTID set")
+	}
+}
+
+func TestEscapeSQLString(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"o'brien", `o\'brien`},
+		{`back\slash`, `back\\slash`},
+		{`both'\`, `both\'\\`},
+	}
+	for _, c := range cases {
+		if got := escapeSQLString(c.in); got != c.want {
+			t.Errorf("escapeSQLString(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Completes the replica-seeding story: the coordinates go-dump captures inside the lock window can now be turned into running replication either **manually** (printed, reviewed SQL) or **automatically** (one command), in GTID `AUTO_POSITION=1` or binlog file/position mode.

### metadata.json
- Now records `mysql_port` alongside `mysql_host` (backward compatible, `omitempty`) — the missing piece for replication setup from the canonical state file.

### go-load --show-replication (manual path)
- Read-only: parses `metadata.json` (plain JSON, no SQL-comment scraping), validates the GTID set with the same sanitizer as `--set-gtid-purged`, and prints ready-to-run SQL to a clean stdout — pipeable into `mysql`.
- GTID auto-position as the runnable block when the dump has a GTID set; file/position and MySQL 5.7 `CHANGE MASTER` as commented variants.
- `--source-host/--source-port/--repl-user/--repl-password` (or `GOLOAD_REPL_PASSWORD`) fill in what metadata can't know; placeholders otherwise.

### go-load --start-replication (automatic path)
- Runs `CHANGE REPLICATION SOURCE` + `START REPLICA` after the load, then polls replica status (15s bound): both threads up → success with lag reported; `Last_IO_Error`/`Last_SQL_Error` → immediate hard error (bad credentials fail in seconds, never a green exit).
- `--replication-mode auto|gtid|file-pos` — auto prefers GTID auto-position when the dump has a GTID set and the target has `gtid_mode=ON`.
- Version-gated syntax: `SOURCE_*`/`START REPLICA` on 8.0.23+, `MASTER_*`/`START SLAVE` on 5.7/pre-8.0.23, `GET_SOURCE_PUBLIC_KEY` vs `GET_MASTER_PUBLIC_KEY` (omitted before 8.0.4).
- Safety gates mirror `--set-gtid-purged`: running channel always aborts; configured-but-stopped requires `--force`; GTID mode requires `gtid_executed` to exactly equal the dump's set (checked with `GTID_SUBTRACT` both directions).
- `--source-ssl` and `--get-source-public-key` for `caching_sha2_password` sources; passwords redacted from all logged statements.

### Docs
- README: complete go-load flags reference, one-command seeding recipe, `--show-replication`/`--start-replication` sections, and how coordinates are captured (FTWRL/LOCK TABLES → snapshots → `SHOW MASTER STATUS` → UNLOCK, all in one lock window).
- docs/GTID-REPLICATION.md: load-time replication marked done with implementation notes.

## Verification

- 21 new unit tests: SQL building (5.7 / 8.0.22 / 8.0.23+), mode resolution, password redaction/escaping, GTID sanitisation, status assessment. `go test ./internal/load/` passes.
- End-to-end against MySQL 8.0.46 source → 8.4 replica (docker matrix):
  - Single command (`--resume --skip-binlog --set-gtid-purged --start-replication`) brought up GTID auto-position replication (IO/SQL Yes, 0s behind) and applied new source writes.
  - `--show-replication` output piped **unedited** into the replica also brought replication up.
  - Wrong password surfaced `Access denied` as a hard error in seconds.
  - `--replication-mode file-pos` came up with `Auto_Position: 0`.
  - The safety gates fired for real along the way: errant-transaction refusal on the container's init GTIDs, subset-requires-`--force`, running-channel refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)